### PR TITLE
Infra 설정 변경

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -95,7 +95,7 @@ jobs:
       id-token: write
       contents: read
     needs: [ build, test ]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
 
     steps:

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Chat.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Chat.java
@@ -26,8 +26,8 @@ public class Chat {
 	@Column(name = "chat_id")
 	private Long id;
 
-	@ManyToOne
-	@JoinColumn(name = "chat_room_id")
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "chat_room_id", nullable = false)
 	private ChatRoom chatRoom;
 
 	// 발신자

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Chat.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Chat.java
@@ -1,7 +1,18 @@
 package com.debateseason_backend_v1.domain.repository.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -10,16 +21,18 @@ import lombok.*;
 @Entity
 public class Chat {
 
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "chat_id")
+	private Long id;
 
-    @Id @GeneratedValue(strategy = GenerationType.AUTO)
-    private long id;
+	@ManyToOne
+	@JoinColumn(name = "chat_room_id")
+	private ChatRoom chatRoom;
 
-    @ManyToOne
-    private ChatRoom chatRoom;
-
-    // 발신자
-    private String sender;
-    // 소속 커뮤니티
-    private String category;
-    private String content;
+	// 발신자
+	private String sender;
+	// 소속 커뮤니티
+	private String category;
+	private String content;
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/ChatRoom.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/ChatRoom.java
@@ -1,7 +1,18 @@
 package com.debateseason_backend_v1.domain.repository.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -10,16 +21,19 @@ import lombok.*;
 @Entity
 public class ChatRoom {
 
-    @Id @GeneratedValue(strategy = GenerationType.AUTO)
-    private long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "chat_room_id")
+	private Long id;
 
-    @ManyToOne
-    private Issue issue;
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "issue_id", nullable = false)
+	private Issue issue;
 
-    private String title;
-    private String content;
+	private String title;
+	private String content;
 
-    private int yes;
+	private int yes;
 
-    private int no;
+	private int no;
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Issue.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Issue.java
@@ -1,7 +1,16 @@
 package com.debateseason_backend_v1.domain.repository.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -10,11 +19,11 @@ import lombok.*;
 @Entity
 public class Issue {
 
-    @Id @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(name = "issue_id")
-    private long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "issue_id")
+	private Long id;
 
-    private String title;
-
+	private String title;
 
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/User.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/User.java
@@ -1,24 +1,34 @@
 package com.debateseason_backend_v1.domain.repository.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 @Setter
 @Builder
 @Entity
-@Table(name = "client") // H2에서는 USER는 예약어라서 사용이 불가함.
+@Table(name = "users")
 public class User {
 
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "user_id")
+	private Long id;
 
-    @Id @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(name = "user_id")
-    private long id;
+	private String username;
+	private String password;
+	private String role;
 
-    private String username;
-    private String password;
-    private String role;
-
-    private String community;
+	private String community;
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/UserIssue.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/UserIssue.java
@@ -1,7 +1,17 @@
 package com.debateseason_backend_v1.domain.repository.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -10,15 +20,15 @@ import lombok.*;
 @Entity
 public class UserIssue {
 
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Id @GeneratedValue(strategy = GenerationType.AUTO)
-    private long id;
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user;
-
-    @ManyToOne
-    @JoinColumn(name = "issue_id")
-    private Issue issue;
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "issue_id", nullable = false)
+	private Issue issue;
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,7 +1,7 @@
 spring:
   config:
     activate:
-      on-profile: prod
+      on-profile: dev
   jpa:
     hibernate:
       ddl-auto: validate
@@ -13,8 +13,8 @@ spring:
     password: ${DB_PASSWORD}
 
     hikari:
-      maximum-pool-size: 10
-      minimum-idle: 5
+      maximum-pool-size: 5
+      minimum-idle: 2
       connection-timeout: 20000
 
   flyway:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,8 +8,7 @@ spring:
         format_sql: true
         show-sql: true
         highlight_sql: true
-    hibernate:
-      ddl-auto: create
+
 
   datasource:
     hikari:

--- a/src/main/resources/db/migration/V0.0.1__init.sql
+++ b/src/main/resources/db/migration/V0.0.1__init.sql
@@ -1,62 +1,54 @@
--- Create sequences
-CREATE SEQUENCE chat_room_seq START WITH 1 INCREMENT BY 50 NOCACHE;
-CREATE SEQUENCE chat_seq START WITH 1 INCREMENT BY 50 NOCACHE;
-CREATE SEQUENCE client_seq START WITH 1 INCREMENT BY 50 NOCACHE;
-CREATE SEQUENCE issue_seq START WITH 1 INCREMENT BY 50 NOCACHE;
-CREATE SEQUENCE user_issue_seq START WITH 1 INCREMENT BY 50 NOCACHE;
-
--- Create tables
+-- 테이블
 CREATE TABLE chat (
-    id BIGINT NOT NULL,
-    chat_room_id BIGINT,
+    chat_id BIGINT NOT NULL AUTO_INCREMENT,
+    chat_room_id BIGINT NOT NULL,
     sender VARCHAR(100),
     category VARCHAR(50),
     content TEXT,
-    PRIMARY KEY (id)
+    PRIMARY KEY (chat_id)
 ) ENGINE=InnoDB;
 
 CREATE TABLE chat_room (
-
-    id BIGINT NOT NULL,
-    issue_issue_id BIGINT,
+    chat_room_id BIGINT NOT NULL AUTO_INCREMENT,
+    issue_id BIGINT NOT NULL,
     title VARCHAR(255),
     content TEXT,
-    yes INTEGER NOT NULL,
-    no INTEGER NOT NULL,
-    PRIMARY KEY (id)
+    yes INTEGER,
+    no INTEGER,
+    PRIMARY KEY (chat_room_id)
 ) ENGINE=InnoDB;
 
-CREATE TABLE client (
-    user_id BIGINT NOT NULL,
-    username VARCHAR(100),
-    password VARCHAR(255),
-    role VARCHAR(50),
+CREATE TABLE users (
+    user_id BIGINT NOT NULL AUTO_INCREMENT,
+    username VARCHAR(100) NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    role VARCHAR(50) NOT NULL,
     community VARCHAR(100),
     PRIMARY KEY (user_id)
 ) ENGINE=InnoDB;
 
 CREATE TABLE issue (
-    issue_id BIGINT NOT NULL,
-    title VARCHAR(255),
+    issue_id BIGINT NOT NULL AUTO_INCREMENT,
+    title VARCHAR(255) ,
     PRIMARY KEY (issue_id)
 ) ENGINE=InnoDB;
 
 CREATE TABLE user_issue (
-    id BIGINT NOT NULL,
-    issue_id BIGINT,
-    user_id BIGINT,
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    issue_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
     PRIMARY KEY (id)
 ) ENGINE=InnoDB;
 
--- Add foreign key constraints
+-- 외래키 제약 조건 추가
 ALTER TABLE chat
     ADD CONSTRAINT fk_chat_chatroom
         FOREIGN KEY (chat_room_id)
-            REFERENCES chat_room (id);
+            REFERENCES chat_room (chat_room_id);
 
 ALTER TABLE chat_room
     ADD CONSTRAINT fk_chatroom_issue
-        FOREIGN KEY (issue_issue_id)
+        FOREIGN KEY (issue_id)
             REFERENCES issue (issue_id);
 
 ALTER TABLE user_issue
@@ -65,6 +57,6 @@ ALTER TABLE user_issue
             REFERENCES issue (issue_id);
 
 ALTER TABLE user_issue
-    ADD CONSTRAINT fk_userissue_client
+    ADD CONSTRAINT fk_userissue_users
         FOREIGN KEY (user_id)
-            REFERENCES client (user_id);
+            REFERENCES users (user_id);


### PR DESCRIPTION
## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
회의에서 제안된 인프라 설정을 적용했습니다.

## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
### 1. 배포 브랜치를 main 에서 develop 으로 변경했습니다.
이제 **develop** 브랜치에 **PR**이 **merge** 되면 자동 배포됩니다.
```YMAL
github.ref == 'refs/heads/main'  ->  github.ref == 'refs/heads/develop'
```


### 2. 엔티티 변경 사항
**2.1 id 필드의 `long` 기본 자료형을 `Long` 참조 자료형으로 변경했습니다.**
```JAVA
private long id;   ->  private Long id;
```


**2.2 엔티티 id 생성 전략을 `AUTO`에서 `IDENTITY`로 변경했습니다.**
```JAVA
@GeneratedValue(strategy = GenerationType.AUTO)  ->  @GeneratedValue(strategy = GenerationType.IDENTITY)
```


**2.3 엔티티의 id 컬럼명을 컨벤션에 맞게 변경했습니다.**
```JAVA
public class Chat {

	@Id
	@GeneratedValue(strategy = GenerationType.IDENTITY)
	@Column(name = "chat_id") // 엔티티 이름_id
	private Long id;
        
        ...
}
```

**2.4 데이터의 무결성을 위해 엔티티의 FK에 `NOT NULL`을 적용했습니다.**
```JAVA
@ManyToOne(optional = false)
@JoinColumn(name = "user_id", nullable = false)
private User user;
```
이 작업을 하지 않으면 FK에 `NULL`이 허용됩니다.


**2.5 User 엔티티의 테이블 명을 통일성을 위해 `client` 에서 `users`로 변경했습니다.**
```JAVA
@Table(name = "client")  -> @Table(name = "users")
```
`user`는 예약어라 사용할 수 없어 `users`로 변경했습니다.

### 3. 환경변수 설정 변경
3.1 `ddl-auto` 설정을 ` application-local.yml`에서  `application-secret.yml`으로 이동
기존의 `jpa.hibernate.ddl-auto` 설정이 `application-local.yml` 환경 변수 설정에 있었습니다. 이는 깃허브에 commit 할 때 원상태로 돌려야 하는 불편이 있었습니다. 때문에 이 설정을 `application-secret.yml` 설정으로 옮기고 자유롭게 변경해서 사용할 수 있도록 하였습니다.

**변경된 application-secret.yml 템플릿**
```YMAL
spring:
  jpa:
    hibernate:
      ddl-auto: create  # 설정을 자유롭게 변경해서 사용하세요!

  datasource:
    driver-class-name: org.mariadb.jdbc.Driver
    url: jdbc:mariadb://localhost:3306/YOUR_DATABASE?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
    username: YOUR_USERNAME
    password: YOUR_PASSWORD
```
**3.2 인스턴스가 다운되는 걸 방지하고자 커넥션풀 설정을 보수적으로 수정했습니다.**
```YMAL
spring:
    hikari:
      maximum-pool-size: 5
      minimum-idle: 2
      connection-timeout: 20000
```
추후 진행될 성능 테스트와 트래픽 유입이 많아질 경우 이에 맞게 설정과 인스턴스 사양을 변경하겠습니다.

### 4. 데이터베이스 형상 관리를 위한 Flyway를 엔티티에 맞게 수정했습니다.
PK와 FK를 제외한 다른 필드들은 정책이 정해지지 않아 NOT NULL 옵션 적용하지 않았습니다. 추후 회의를 통해 필드값의 NOT NULL 여부를 알려주시면 적용하겠습니다.

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->

