### PR TITLE
Feature/stomp room messaging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 
     // Monitoring
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/controller/WebSocketControllerV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/controller/WebSocketControllerV1.java
@@ -33,6 +33,7 @@ public class WebSocketControllerV1 {
             .sender(chatMessage.getSender())
             .content(chatMessage.getContent())
             .opinionType(chatMessage.getOpinionType())
+            .userCommunity(chatMessage.getUserCommunity())
             .timeStamp(LocalDateTime.now())
             .build();
     }
@@ -49,6 +50,7 @@ public class WebSocketControllerV1 {
                 .sender(chatMessage.getSender())
                 .content(chatMessage.getContent())
                 .opinionType(chatMessage.getOpinionType())
+                .userCommunity(chatMessage.getUserCommunity())
                 .timeStamp(LocalDateTime.now())
                 .build();
     }
@@ -61,10 +63,12 @@ public class WebSocketControllerV1 {
             @Payload ChatMessage chatMessage
     ) {
         return ChatMessage.builder()
-                .type(MessageType.JOIN)
-                .sender(chatMessage.getSender())
-                .content(chatMessage.getSender() + " joined!")
-                .timeStamp(LocalDateTime.now())
-                .build();
+            .type(MessageType.JOIN)
+            .sender(chatMessage.getSender())
+            .content(chatMessage.getContent() + " joined!")
+            .opinionType(chatMessage.getOpinionType())
+            .userCommunity(chatMessage.getUserCommunity())
+            .timeStamp(LocalDateTime.now())
+            .build();
     }
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/model/ChatMessage.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/model/ChatMessage.java
@@ -34,6 +34,9 @@ public class ChatMessage {
     private String sender;
     @Schema(description = "토론찬반", example = "AGREE")
     private OpinionType opinionType;
+    @Schema(description = "사용자 소속 커뮤니티", example = "에펨코리아")
+    private String userCommunity;
+
     @JsonSerialize(using = LocalDateTimeSerializer.class) // 직렬화 시 필요
     @JsonDeserialize(using = LocalDateTimeDeserializer.class) // 역직렬화 시 필요
     @Schema(description = "메시지 받은 날짜 시간")

--- a/src/test/java/com/debateseason_backend_v1/domain/chat/controller/WebSocketControllerV1Test.java
+++ b/src/test/java/com/debateseason_backend_v1/domain/chat/controller/WebSocketControllerV1Test.java
@@ -1,11 +1,11 @@
 package com.debateseason_backend_v1.domain.chat.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.lang.reflect.Type;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,11 +23,12 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.socket.client.WebSocketClient;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
-
 import com.debateseason_backend_v1.common.enums.MessageType;
 import com.debateseason_backend_v1.domain.chat.model.ChatMessage;
-
 import lombok.extern.slf4j.Slf4j;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @ActiveProfiles("test")
@@ -41,6 +42,9 @@ class WebSocketControllerV1Test {
     private WebSocketStompClient stompClient;
     private StompSession stompSession;
     private BlockingQueue<ChatMessage> blockingQueue;
+
+    private static final String TEST_CHAT_CONTENT = "테스트 메시지";
+    private static final String TEST_CHAT_SENDER = "testUser";
 
     @BeforeEach
     void setup() {
@@ -57,7 +61,9 @@ class WebSocketControllerV1Test {
             log.info("웹소켓에 연결을 시도 중입니다...  : {}", wsUrl);
             stompSession = stompClient.connect(wsUrl, new StompSessionHandlerAdapter() {}).get(5, TimeUnit.SECONDS);
             // 연결 여부 확인
-            assertTrue(stompSession.isConnected(), "WebSocket 세션이 연결되지 않았습니다.");
+            assertThat(stompSession.isConnected())
+                .withFailMessage("WebSocket 세션이 연결되지 않았습니다.")
+                .isTrue();
         } catch (Exception e) {
             fail("웹소켓 연결 실패 : " + e.getMessage());
         }
@@ -79,6 +85,7 @@ class WebSocketControllerV1Test {
             }
         };
 
+
         // 구독 수행 후 완료 대기 시간을 500ms
         stompSession.subscribe("/topic/public", frameHandler);
         Thread.sleep(500); // 구독 완료 대기
@@ -86,17 +93,17 @@ class WebSocketControllerV1Test {
         // 메시지 생성 및 전송
         ChatMessage message = ChatMessage.builder()
                 .type(MessageType.CHAT)
-                .content("테스트 메시지")
-                .sender("testUser")
+                .content(TEST_CHAT_CONTENT)
+                .sender(TEST_CHAT_SENDER)
                 .build();
 
         stompSession.send("/stomp/chat.sendMessage", message);
 
         // 메시지 큐 확인 (큐가 비어있으면 테스트 실패)
         ChatMessage received = blockingQueue.poll(5, TimeUnit.SECONDS);
-        assertNotNull(received, "메시지 수신 되지 않음.");
-        assertEquals("테스트 메시지", received.getContent());
-        assertEquals("testUser", received.getSender());
+        assertThat(received).withFailMessage("메시지 수신 되지 않음").isNotNull();
+        assertThat(received.getContent()).withFailMessage("메시지 Content는 \"%s\" 이여야 하나, 테스트에 사용된 Content는 \"%s\" 입니다.",TEST_CHAT_CONTENT,received.getContent()).isEqualTo(TEST_CHAT_CONTENT);
+        assertThat(received.getSender()).withFailMessage("Sender는 \"%s\" 이여야 하나, 테스트에 사용된 Sender는 \"%s\" 입니다.", TEST_CHAT_SENDER, received.getSender()).isEqualTo(TEST_CHAT_SENDER);
 
         // 테스트 후 연결 정리
         if (stompSession != null && stompSession.isConnected()) {
@@ -104,6 +111,7 @@ class WebSocketControllerV1Test {
             log.info("stompSession disconnected");
         }
     }
+
 
     @AfterEach
     void close() {


### PR DESCRIPTION
## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
1. ChatMessage클래스 userCommunity 필드 추가
2. AssertJ 의존성추가
3. Junit -> AssertJ 테스트코드 마이그레이션
4. WebSocketControllerV1Test에 사용되는 구독 핸들러 분리
5. 테스트 실패 메시지 구체화


## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #26 

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
1. ChatMessage클래스 userCommunity 필드 추가  
   - 채팅주고 받는 데이터에 유저 소속이 필요해 추가
3. AssertJ 의존성추가
   - 지난 스크럼에서 테스트코드 가독성을 위해 사용하기로 결정하여 의존성 추가
4. Junit -> AssertJ 테스트코드 마이그레이션
5. WebSocketControllerV1Test에 사용되는 구독 핸들러 분리
   - 구독 핸들러 분리전 테스트 코드마다 중복 코드가 발생하여 재사용할 수 있겠금 분리
6. 테스트 실패 메시지 구체화
   - 테스트 실패시 구체적으로 기대값과 결과값을 출력해 바로 실패 메시지를 이해 할 수 있게 테스트 실패 메시지 구체화

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->

