### PR TITLE
feat: WebSocket 연결 설정 및 타임아웃 구성

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/config/WebSocketConfig.java
+++ b/src/main/java/com/debateseason_backend_v1/config/WebSocketConfig.java
@@ -1,13 +1,18 @@
 package com.debateseason_backend_v1.config;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.config.annotation.*;
+import org.springframework.web.socket.handler.WebSocketHandlerDecorator;
 
 @Configuration
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
+@Slf4j
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
@@ -19,8 +24,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry register) {
         register.addEndpoint("/ws-stomp")
-            .setAllowedOrigins("*")
-            .withSockJS();
+                .setAllowedOriginPatterns("*")
+            .withSockJS()
+                .setWebSocketEnabled(true)  // WebSocket 활성화
+                .setHeartbeatTime(60000)    // 하트비트 간격
+                .setDisconnectDelay(3000);  // 연결 해제 지연;
+                //.setClientLibraryUrl("https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js");
+
     }
 
 }


### PR DESCRIPTION
- Heartbeat 60초로 증가: 서버 부하 감소
- Disconnect 3초로 감소: 빠른 리소스 해제
- 대량 트래픽 환경 최적화

## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
- Heartbeat 간격: 25초 → 60초
- Disconnect delay: 5초 → 3초


## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
```java
.withSockJS()
    .setWebSocketEnabled(true)
    .setHeartbeatTime(60000)    // 1분
    .setDisconnectDelay(3000);  // 3초
```

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->

