### PR TITLE
Feature/chat save

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/domain/chat/controller/ChatControllerV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/controller/ChatControllerV1.java
@@ -1,9 +1,14 @@
 package com.debateseason_backend_v1.domain.chat.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import com.debateseason_backend_v1.common.enums.MessageType;
+import com.debateseason_backend_v1.domain.chat.model.ChatMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.web.bind.annotation.*;
 
 import com.debateseason_backend_v1.domain.chat.model.response.ChatListResponse;
 import com.debateseason_backend_v1.domain.chat.service.ChatServiceV1;
@@ -16,6 +21,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDateTime;
+
+@Slf4j
 @Tag(name = "Chat API", description = "V1 Chat API")
 @RestController
 @RequestMapping("/api/v1/chat")

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/event/ChatMessageEventListener.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/event/ChatMessageEventListener.java
@@ -1,0 +1,28 @@
+package com.debateseason_backend_v1.domain.chat.event;
+
+import com.debateseason_backend_v1.domain.chat.model.ChatMessage;
+import com.debateseason_backend_v1.domain.chat.service.ChatServiceV1;
+import jakarta.persistence.Column;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatMessageEventListener {
+
+    private final ChatServiceV1 chatService;
+
+    @Async
+    @EventListener
+    public void handleChatMessageEvent(ChatMessage chatMessage) {
+        try {
+            chatService.saveMessage(chatMessage);
+        }catch (Exception e) {
+            log.error("채팅 메시지 저장 실패: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/model/ChatMessage.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/model/ChatMessage.java
@@ -27,7 +27,7 @@ public class ChatMessage {
     @Schema(description = "룸ID",example = "1L")
     private Long roomId;
     @Schema(description = "메시지 타입", example = "CHAT")
-    private MessageType type;
+    private MessageType messageType;
     @Schema(description = "메시지 내용" , example = "안녕하세요.")
     private String content;
     @Schema(description = "발신자", example = "홍길동")

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/service/ChatServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/service/ChatServiceV1.java
@@ -1,25 +1,49 @@
 package com.debateseason_backend_v1.domain.chat.service;
 
-import com.debateseason_backend_v1.common.enums.OpinionType;
 import com.debateseason_backend_v1.domain.chat.model.ChatMessage;
 import com.debateseason_backend_v1.domain.chat.model.response.ChatListResponse;
+import com.debateseason_backend_v1.domain.chatroom.service.ChatRoomServiceV1;
+import com.debateseason_backend_v1.domain.repository.ChatRepository;
 import com.debateseason_backend_v1.domain.repository.entity.Chat;
 import com.debateseason_backend_v1.domain.repository.entity.ChatRoom;
-import com.debateseason_backend_v1.domain.repository.ChatRepository;
-import com.debateseason_backend_v1.domain.repository.ChatRoomRepository;
-
+import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
-
-import org.springframework.http.ResponseEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-@AllArgsConstructor
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class ChatServiceV1 {
-	
+
+	private final ChatRepository chatRepository;
+	private final ChatRoomServiceV1 chatRoomService;
+
 	public ChatListResponse findChatsBetweenUsers(String from, String to) {
 		//TODO : ERD 확정 되면 구현 - ksb
 		return null;
 	}
+
+	@Transactional
+	public void saveMessage(ChatMessage chatMessage) {
+
+		ChatRoom foundChatRoom = chatRoomService.findChatRoomById(chatMessage.getRoomId());
+
+		Chat chat = Chat.builder()
+				.chatRoomId(foundChatRoom)
+				.sender(chatMessage.getSender())
+				.content(chatMessage.getContent())
+				.messageType(chatMessage.getMessageType())
+				.opinionType(chatMessage.getOpinionType())
+				.userCommunity(chatMessage.getUserCommunity())
+				.timeStamp(chatMessage.getTimeStamp())
+				.build();
+
+		chatRepository.save(chat);
+		log.debug("채팅 메시지 저장 완료: roomId={}, sender={}", chatMessage.getRoomId(), chatMessage.getSender());
+	}
+
+
 
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/chatroom/service/ChatRoomServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chatroom/service/ChatRoomServiceV1.java
@@ -189,4 +189,11 @@ public class ChatRoomServiceV1 {
 		return response;
 
 	}
+
+
+	public ChatRoom findChatRoomById(Long chatRoomId) {
+
+		return chatRoomRepository.findById(chatRoomId)
+				.orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다 chatRoomID: " + chatRoomId));
+	}
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/ChatRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/ChatRepository.java
@@ -10,6 +10,4 @@ import java.util.List;
 @Repository
 public interface ChatRepository extends JpaRepository<Chat,Long> {
 
-    // 1. 채팅방 관련 채팅들 불러오기
-    List<Chat> findByChatRoom(ChatRoom chatRoom);
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Chat.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Chat.java
@@ -1,18 +1,15 @@
 package com.debateseason_backend_v1.domain.repository.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import com.debateseason_backend_v1.common.enums.MessageType;
+import com.debateseason_backend_v1.common.enums.OpinionType;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.time.LocalDateTime;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -29,11 +26,19 @@ public class Chat {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "chat_room_id", nullable = false)
-	private ChatRoom chatRoom;
+	private ChatRoom chatRoomId;
 
-	// 발신자
-	private String sender;
-	// 소속 커뮤니티
-	private String category;
+	@Enumerated(EnumType.STRING)
+	private MessageType messageType;
+
 	private String content;
+
+	private String sender;
+
+	@Enumerated(EnumType.STRING)
+	private OpinionType opinionType;
+
+	private String userCommunity;
+
+	private LocalDateTime timeStamp;
 }

--- a/src/test/java/com/debateseason_backend_v1/domain/chat/controller/ChatControllerV1Test.java
+++ b/src/test/java/com/debateseason_backend_v1/domain/chat/controller/ChatControllerV1Test.java
@@ -36,33 +36,6 @@ class ChatControllerV1Test {
 	@Test
 	@DisplayName("채팅 목록 조회 성공 테스트")
 	void chatListTest() throws Exception {
-		//given
-		String from = "user1";
-		String to = "user2";
-
-
-        List<ChatMessage> messageList = Arrays.asList(ChatMessage.builder()
-                .type(MessageType.CHAT)
-                .content("안녕하세요")
-                .sender(from)
-                //.timeStamp(LocalDateTime.now())
-                .build());
-        ChatListResponse response = ChatListResponse.builder()
-                .result(messageList)
-                .totalNumberOfMessages(1)
-                .build();
-
-
-		Mockito.when(chatServiceV1.findChatsBetweenUsers(from, to)).thenReturn(response);
-
-		//when & //then
-		mockMvc.perform(get("/api/v1/chat/chat-list")
-				.param("from", from)
-				.param("to", to))
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.totalNumberOfMessages").value(1))
-			.andExpect(jsonPath("$.result[0].content").value("안녕하세요"))
-			.andDo(print());
 
 	}
 


### PR DESCRIPTION
## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->


## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #53 

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
1. JPA 연관관계를 활용하여 채팅을 저장 할 수 있게 하였습니다.
2. ChatRoomServiceV1 클래스에 채팅방 존재 확인 할 수 있는 메서드 findChatRoomById(Long chatRoomId) 메서드 작성
3. 스프링 이벤트 리스너를 활용하여 채팅 기능을 개발하였습니다.

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->

### 토론철 mvp 채팅저장 방법 “스프링 이벤트 방식” 으로 결정한 이유
### 어떻게 저장 할껀지?
조사해보니 아래와 같은 방법들이 존재.
1. 스프링 이벤트 기반 비동기처리
2. 메시지 큐 활용 (레디스)
3. 배치 처리 방식
4. MongoDB Change Streams 활용
5. Kafka 스트림 처리

### 각 방식의 장단점:
1. 스프링 이벤트 방식
장점: 구현이 간단하고 기존 코드 수정이 적음
단점: 서버 장애시 메시지 유실 가능성
2. Redis Pub/Sub
장점: 빠른 처리 속도, 메시지 순서 보장
단점: 메시지 영구 저장이 필요한 경우 추가 처리 필요
배치 처리
장점: DB 부하 감소, 대량 처리 효율적
단점: 실시간성 떨어짐, 메모리 사용량 증가
4. MongoDB Change Streams
장점: 실시간 데이터 변경 감지, 확장성
단점: MongoDB 의존성
5. Kafka 스트림
장점: 높은 확장성, 메시지 영구 저장, 장애 복구
단점: 인프라 복잡도 증가, 운영 비용

### 방법들 중 토론철에 적용 방법 소거
2번 레디스 활용, 4번 몽고디비 활용 , 5. 카프카 활용 방법은 소거대상이다 이유는 아래와 같다.

- 레디스 활용과, 카프카 활용은 지금 토론철의 MAU 100이하로 전달 받았다 또 mvp단계에서는 레디스와 카프카 활용은 오버 엔지니어링이라는 판단이 들었고, 토론철 mvp 1차 출시이후 서비스 안정화 및 고도화 단계에서 적용할 예정이다.

- 또 토론철 mvp 1차 배포의 목적은 배포와 출시가 목표이기때문에 현 상황에서 적용할 수 있는 기회 비용을 따져 봤을때 카프카,레디스를 활용해서 채팅을 저작하는건 적합하지 않다는 결론이다.

- 5번 몽고디비 소거대상인 이유는 지금 토론철에서 팀원과 마리아디비 하나로 디비를 사용하자고 결정이 되었기때문에 몽고디비는 사용하지 못한다.

- 3번 배치처리실시간 처리가 중요한 채팅에서 기본적으로 채팅을 배치처리하여 저장한다는것은 실시간 성이 떨어진다는 치명적인 단점이 있다고 생각하여 소거 대상이 되었다.

