### PR TITLE
회원탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/DebateSeasonBackendV1Application.java
+++ b/src/main/java/com/debateseason_backend_v1/DebateSeasonBackendV1Application.java
@@ -3,10 +3,12 @@ package com.debateseason_backend_v1;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.servers.Server;
 
+@EnableScheduling
 @OpenAPIDefinition(servers = {@Server(url = "https://debate-season.click",description = "Swagger https 프로토콜 적용")})
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class) // 자동으로 날짜 입력활성화
 public class DebateSeasonBackendV1Application {

--- a/src/main/java/com/debateseason_backend_v1/common/component/UuidShortener.java
+++ b/src/main/java/com/debateseason_backend_v1/common/component/UuidShortener.java
@@ -1,0 +1,38 @@
+package com.debateseason_backend_v1.common.component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class UuidShortener {
+
+	public String shortenUuid() {
+
+		String uuid = UUID.randomUUID().toString();
+
+		// 1. UUID를 UTF-8 바이트 배열로 변환
+		byte[] uuidBytes = uuid.getBytes(StandardCharsets.UTF_8);
+
+		try {
+			// 2. SHA-256 해시 적용
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] hashedBytes = digest.digest(uuidBytes);
+
+			// 3. 해시된 바이트 배열의 앞 8바이트를 16진수 문자열로 변환
+			StringBuilder result = new StringBuilder();
+			for (int i = 0; i < 4; i++) {
+				result.append(String.format("%02x", hashedBytes[i]));
+			}
+
+			// 4. 8자리 문자열 반환
+			return result.toString();
+
+		} catch (NoSuchAlgorithmException e) {
+			throw new RuntimeException("UUID 변환 중 오류 발생", e);
+		}
+	}
+}

--- a/src/main/java/com/debateseason_backend_v1/common/exception/ErrorCode.java
+++ b/src/main/java/com/debateseason_backend_v1/common/exception/ErrorCode.java
@@ -28,9 +28,9 @@ public enum ErrorCode implements CodeInterface {
 	VALUE_OUT_OF_RANGE(103, HttpStatus.BAD_REQUEST, "입력값이 허용 범위를 벗어났습니다"),
 
 	// 1000번대 JWT 에러
-	TOKEN_EXPIRED(1000, HttpStatus.UNAUTHORIZED, "인증이 만료되었습니다. 다시 로그인해주세요."),
-	INVALID_TOKEN(1001, HttpStatus.UNAUTHORIZED, "유효하지 않은 인증입니다."),
-	NOT_SUPPORTED_SOCIAL_TYPE(1002, HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 타입입니다"),
+	EXPIRED_ACCESS_TOKEN(1000, HttpStatus.UNAUTHORIZED, "Access Token이 만료되었습니다. 다시 로그인해주세요."),
+	EXPIRED_REFRESH_TOKEN(1004, HttpStatus.UNAUTHORIZED, "Refresh Token이 만료되었습니다. 다시 로그인해주세요."),
+	INVALID_ACCESS_TOKEN(1001, HttpStatus.UNAUTHORIZED, "유효하지 않은 Access Token 입니다."),
 	INVALID_REFRESH_TOKEN(1003, HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token 입니다."),
 
 	// 2000번대 프로필 관련 에러
@@ -43,6 +43,7 @@ public enum ErrorCode implements CodeInterface {
 	NOT_SUPPORTED_GENDER_TYPE(2007, HttpStatus.BAD_REQUEST, "지원하지 않는 성별 타입입니다"),
 	NOT_SUPPORTED_AGE_RANGE(2008, HttpStatus.BAD_REQUEST, "지원하지 않는 연령대입니다"),
 	NOT_SUPPORTED_COMMUNITY(2009, HttpStatus.BAD_REQUEST, "지원하지 않는 커뮤니티입니다."),
+	NOT_SUPPORTED_SOCIAL_TYPE(2010, HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 타입입니다"),
 
 	// 3000번대 유저 관련 에러
 	USER_NOT_FOUND(3000, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/debateseason_backend_v1/common/exception/ErrorCode.java
+++ b/src/main/java/com/debateseason_backend_v1/common/exception/ErrorCode.java
@@ -44,6 +44,9 @@ public enum ErrorCode implements CodeInterface {
 	NOT_SUPPORTED_AGE_RANGE(2008, HttpStatus.BAD_REQUEST, "지원하지 않는 연령대입니다"),
 	NOT_SUPPORTED_COMMUNITY(2009, HttpStatus.BAD_REQUEST, "지원하지 않는 커뮤니티입니다."),
 
+	// 3000번대 유저 관련 에러
+	USER_NOT_FOUND(3000, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
 	// API 요청 에러
 	BAD_REQUEST(400, HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
 

--- a/src/main/java/com/debateseason_backend_v1/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/debateseason_backend_v1/common/exception/GlobalExceptionHandler.java
@@ -29,7 +29,7 @@ public class GlobalExceptionHandler {
 
 	// CustomException 발생 시 처리
 	@ExceptionHandler(CustomException.class)
-	public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+	protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
 
 		log.error("CustomException occurred. ErrorCode: {}, Message: {}",
 			e.getCodeInterface().getCode(),

--- a/src/main/java/com/debateseason_backend_v1/domain/auth/controller/docs/AuthControllerV1Docs.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/auth/controller/docs/AuthControllerV1Docs.java
@@ -53,6 +53,26 @@ public interface AuthControllerV1Docs {
 			)
 		),
 		@ApiResponse(
+			responseCode = "400",
+			description = "잘못된 요청",
+			content = @Content(
+				mediaType = "application/json",
+				examples = {
+					@ExampleObject(
+						name = "MissingRequiredValue",
+						summary = "필수 입력값에 빈 문자열 입력",
+						value = """
+							{
+							    "status": 400,
+							    "code": "MISSING_REQUIRED_VALUE",
+							    "message": "Refresh Token은 필수 값입니다."
+							}
+							"""
+					)
+				}
+			)
+		),
+		@ApiResponse(
 			responseCode = "401",
 			description = "유효하지 않은 Refresh Token",
 			content = @Content(

--- a/src/main/java/com/debateseason_backend_v1/domain/community/controller/docs/CommunityControllerV1Docs.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/community/controller/docs/CommunityControllerV1Docs.java
@@ -47,12 +47,12 @@ public interface CommunityControllerV1Docs {
 						        {
 						            "id": 1,
 						            "name": "디시인사이드",
-						            "iconUrl": "https://d1aqrs2xenvfsd.cloudfront.net/community/icons/dcinside.png"
+						            "iconUrl": "community/icons/dcinside.png"
 						        },
 						        {
 						            "id": 2,
 						            "name": "에펨코리아",
-						            "iconUrl": "https://d1aqrs2xenvfsd.cloudfront.net/community/icons/fmkorea.png"
+						            "iconUrl": "community/icons/fmkorea.png"
 						        }
 						    ]
 						}
@@ -105,7 +105,7 @@ public interface CommunityControllerV1Docs {
 							        {
 							            "id": 1,
 							            "name": "디시인사이드",
-							            "iconUrl": "https://d1aqrs2xenvfsd.cloudfront.net/community/icons/dcinside.png"
+							            "iconUrl": "community/icons/dcinside.png"
 							        }
 							    ]
 							}

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/RefreshTokenRepository.java
@@ -3,6 +3,8 @@ package com.debateseason_backend_v1.domain.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.debateseason_backend_v1.domain.repository.entity.RefreshToken;
 
@@ -11,6 +13,10 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 	Optional<RefreshToken> findByToken(String token);
 
 	void deleteByToken(String token);
+
+	@Modifying
+	@Query("DELETE FROM RefreshToken rt WHERE rt.user.id = :userId")
+	void deleteAllByUserId(Long userId);
 
 	boolean existsByToken(String token);
 

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/UserRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/UserRepository.java
@@ -1,5 +1,7 @@
 package com.debateseason_backend_v1.domain.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,5 +15,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findBySocialTypeAndIdentifier(SocialType socialType, String identifier);
 
+	List<User> findByIsDeletedTrueAndUpdatedAtBefore(LocalDateTime cutoffDate);
 }
-

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Profile.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Profile.java
@@ -64,7 +64,7 @@ public class Profile {
 	}
 
 	public void update(String nickname, GenderType gender, AgeRangeType ageRange) {
-		
+
 		if (!Objects.equals(nickname, this.nickname)) {
 			this.nickname = nickname;
 		}
@@ -74,6 +74,12 @@ public class Profile {
 		if (!Objects.equals(ageRange, this.ageRange)) {
 			this.ageRange = ageRange;
 		}
+	}
+
+	public void anonymize(String anonymousNickname) {
+
+		this.nickname = anonymousNickname;
+		this.gender = GenderType.UNDEFINED;
 	}
 
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/User.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/User.java
@@ -2,9 +2,6 @@ package com.debateseason_backend_v1.domain.repository.entity;
 
 import java.time.LocalDateTime;
 
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
-import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -70,6 +67,11 @@ public class User {
 	public void restore() {
 
 		this.isDeleted = false;
+	}
+
+	public void anonymize(String uuid) {
+
+		this.identifier = uuid;
 	}
 
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/User.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/User.java
@@ -2,7 +2,11 @@ package com.debateseason_backend_v1.domain.repository.entity;
 
 import java.time.LocalDateTime;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.debateseason_backend_v1.domain.user.enums.SocialType;
@@ -40,19 +44,32 @@ public class User {
 	@Column(name = "identifier")
 	private String identifier;
 
-	// TODO: IssueServiceV1 에러 때문에 User 엔티티에 위치, Profile 로 옮겨야 함.
-	@Column(name = "community")
-	private String community;
+	@Column(name = "is_deleted")
+	private boolean isDeleted = false;
 
 	@CreatedDate
 	@Column(name = "created_at", updatable = false)
 	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "update_at")
+	private LocalDateTime updatedAt;
 
 	@Builder
 	private User(SocialType socialType, String externalId) {
 
 		this.socialType = socialType;
 		this.identifier = externalId;
+	}
+
+	public void withdraw() {
+
+		this.isDeleted = true;
+	}
+
+	public void restore() {
+
+		this.isDeleted = false;
 	}
 
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/user/controller/UserControllerV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/controller/UserControllerV1.java
@@ -48,6 +48,16 @@ public class UserControllerV1 implements UserControllerV1Docs {
 		return VoidApiResult.success("로그아웃 성공");
 	}
 
+	@PostMapping("/withdraw")
+	public VoidApiResult withdraw(
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	){
+
+		userServiceV1.withdraw(userDetails.getUserId());
+
+		return VoidApiResult.success("회원 탈퇴가 완료되었습니다.");
+	}
+
 	// 2. 인덱스 페이지(홈)
 	// 이슈방 전체 나열
 	@Operation(

--- a/src/main/java/com/debateseason_backend_v1/domain/user/controller/UserControllerV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/controller/UserControllerV1.java
@@ -30,11 +30,11 @@ public class UserControllerV1 implements UserControllerV1Docs {
 	private final IssueServiceV1 issueServiceV1;
 
 	@PostMapping("/login")
-	public ApiResult<LoginResponse> socialLogin(@Valid @RequestBody SocialLoginRequest request) {
+	public ApiResult<LoginResponse> login(@Valid @RequestBody SocialLoginRequest request) {
 
 		LoginResponse response = userServiceV1.socialLogin(request.toServiceRequest());
 
-		return ApiResult.success("소셜 로그인 성공", response);
+		return ApiResult.success("로그인을 성공했습니다.", response);
 	}
 
 	@PostMapping("/logout")
@@ -45,7 +45,7 @@ public class UserControllerV1 implements UserControllerV1Docs {
 
 		userServiceV1.logout(request.toServiceRequest(userDetails.getUserId()));
 
-		return VoidApiResult.success("로그아웃 성공");
+		return VoidApiResult.success("로그아웃을 성공했습니다.");
 	}
 
 	@PostMapping("/withdraw")

--- a/src/main/java/com/debateseason_backend_v1/domain/user/controller/UserControllerV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/controller/UserControllerV1.java
@@ -51,7 +51,7 @@ public class UserControllerV1 implements UserControllerV1Docs {
 	@PostMapping("/withdraw")
 	public VoidApiResult withdraw(
 		@AuthenticationPrincipal CustomUserDetails userDetails
-	){
+	) {
 
 		userServiceV1.withdraw(userDetails.getUserId());
 

--- a/src/main/java/com/debateseason_backend_v1/domain/user/controller/docs/ProfileControllerV1Docs.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/controller/docs/ProfileControllerV1Docs.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.debateseason_backend_v1.common.response.ApiResult;
+import com.debateseason_backend_v1.common.response.ErrorResponse;
 import com.debateseason_backend_v1.common.response.VoidApiResult;
 import com.debateseason_backend_v1.domain.user.controller.request.ProfileRegisterRequest;
 import com.debateseason_backend_v1.domain.user.controller.request.ProfileUpdateRequest;
@@ -75,6 +76,28 @@ public interface ProfileControllerV1Docs {
 				mediaType = "application/json",
 				examples = {
 					@ExampleObject(
+						name = "MissingSingleRequiredValue",
+						summary = "필수 입력값에 빈 문자열 입력",
+						value = """
+							{
+							    "status": 400,
+							    "code": "MISSING_REQUIRED_VALUE",
+							    "message": "닉네임은 필수입니다."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "MissingMultipleRequiredValue",
+						summary = "필수 입력값에 빈 문자열 입력(여러 개)",
+						value = """
+							{
+							    "status": 400,
+							    "code": "MISSING_REQUIRED_VALUE",
+							    "message": "닉네임은 필수입니다., 커뮤니티 선택은 필수입니다."
+							}
+							"""
+					),
+					@ExampleObject(
 						name = "InvalidNickname",
 						summary = "잘못된 닉네임 형식",
 						value = """
@@ -104,6 +127,42 @@ public interface ProfileControllerV1Docs {
 							    "status": 400,
 							    "code": "NOT_SUPPORTED_AGE_RANGE",
 							    "message": "지원하지 않는 연령대입니다"
+							}
+							"""
+					)
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "401",
+			description = "인증 실패",
+			content = @Content(
+				mediaType = "application/json",
+				schema = @Schema(
+					oneOf = {
+						ErrorResponse.class
+					}
+				),
+				examples = {
+					@ExampleObject(
+						name = "ExpiredAccessToken",
+						summary = "만료된 Access Token",
+						value = """
+							{
+							    "status": 401,
+							    "code": "EXPIRED_ACCESS_TOKEN",
+							    "message": "Access Token이 만료되었습니다. 다시 로그인해주세요."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "InvalidAccessToken",
+						summary = "유효하지 않은 Access Token",
+						value = """
+							{
+							    "status": 401,
+							    "code": "INVALID_ACCESS_TOKEN",
+							    "message": "유효하지 않은 Access Token 입니다."
 							}
 							"""
 					)
@@ -171,6 +230,42 @@ public interface ProfileControllerV1Docs {
 						}
 						"""
 				)
+			)
+		),
+		@ApiResponse(
+			responseCode = "401",
+			description = "인증 실패",
+			content = @Content(
+				mediaType = "application/json",
+				schema = @Schema(
+					oneOf = {
+						ErrorResponse.class
+					}
+				),
+				examples = {
+					@ExampleObject(
+						name = "ExpiredAccessToken",
+						summary = "만료된 Access Token",
+						value = """
+							{
+							    "status": 401,
+							    "code": "EXPIRED_ACCESS_TOKEN",
+							    "message": "Access Token이 만료되었습니다. 다시 로그인해주세요."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "InvalidAccessToken",
+						summary = "유효하지 않은 Access Token",
+						value = """
+							{
+							    "status": 401,
+							    "code": "INVALID_ACCESS_TOKEN",
+							    "message": "유효하지 않은 Access Token 입니다."
+							}
+							"""
+					)
+				}
 			)
 		),
 		@ApiResponse(
@@ -243,6 +338,28 @@ public interface ProfileControllerV1Docs {
 				mediaType = "application/json",
 				examples = {
 					@ExampleObject(
+						name = "MissingSingleRequiredValue",
+						summary = "필수 입력값에 빈 문자열 입력",
+						value = """
+							{
+							    "status": 400,
+							    "code": "MISSING_REQUIRED_VALUE",
+							    "message": "닉네임은 필수입니다."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "MissingMultipleRequiredValue",
+						summary = "필수 입력값에 빈 문자열 입력(여러 개)",
+						value = """
+							{
+							    "status": 400,
+							    "code": "MISSING_REQUIRED_VALUE",
+							    "message": "닉네임은 필수입니다., 커뮤니티 선택은 필수입니다."
+							}
+							"""
+					),
+					@ExampleObject(
 						name = "InvalidNickname",
 						summary = "잘못된 닉네임 형식",
 						value = """
@@ -250,6 +367,53 @@ public interface ProfileControllerV1Docs {
 							    "status": 400,
 							    "code": "INVALID_NICKNAME_FORMAT",
 							    "message": "닉네임은 한글 또는 영문으로 8자 이내로 입력해주세요."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "InvalidAgeRange",
+						summary = "잘못된 연령대",
+						value = """
+							{
+							    "status": 400,
+							    "code": "NOT_SUPPORTED_AGE_RANGE",
+							    "message": "지원하지 않는 연령대입니다"
+							}
+							"""
+					)
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "401",
+			description = "인증 실패",
+			content = @Content(
+				mediaType = "application/json",
+				schema = @Schema(
+					oneOf = {
+						ErrorResponse.class
+					}
+				),
+				examples = {
+					@ExampleObject(
+						name = "ExpiredAccessToken",
+						summary = "만료된 Access Token",
+						value = """
+							{
+							    "status": 401,
+							    "code": "EXPIRED_ACCESS_TOKEN",
+							    "message": "Access Token이 만료되었습니다. 다시 로그인해주세요."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "InvalidAccessToken",
+						summary = "유효하지 않은 Access Token",
+						value = """
+							{
+							    "status": 401,
+							    "code": "INVALID_ACCESS_TOKEN",
+							    "message": "유효하지 않은 Access Token 입니다."
 							}
 							"""
 					)

--- a/src/main/java/com/debateseason_backend_v1/domain/user/controller/docs/ProfileControllerV1Docs.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/controller/docs/ProfileControllerV1Docs.java
@@ -26,7 +26,10 @@ public interface ProfileControllerV1Docs {
 
 	@Operation(
 		summary = "프로필 등록",
-		description = "JWT 토큰에서 사용자 ID를 추출하여 프로필을 등록합니다. Access Token이 필요합니다.",
+		description = """
+			✅ API를 사용하려면 Access Token이 필요합니다. \n
+			JWT 토큰에서 사용자 ID를 추출하여 프로필을 등록합니다.
+			""",
 		security = @SecurityRequirement(name = "JWT")
 	)
 	@io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -131,7 +134,10 @@ public interface ProfileControllerV1Docs {
 
 	@Operation(
 		summary = "내 프로필 조회",
-		description = "JWT 토큰에서 사용자 ID를 추출하여 자신의 프로필을 조회합니다. Access Token이 필요합니다."
+		description = """
+			✅ API를 사용하려면 Access Token이 필요합니다. \n
+			JWT 토큰에서 사용자 ID를 추출하여 자신의 프로필을 조회합니다.
+			"""
 	)
 	@ApiResponses(value = {
 		@ApiResponse(
@@ -159,7 +165,7 @@ public interface ProfileControllerV1Docs {
 						        "community": {
 						            "id": 1,
 						            "name": "디시",
-						            "iconUrl": "https://d1aqrs2xenvfsd.cloudfront.net/community/icons/dcinside.png"
+						            "iconUrl": "community/icons/dcinside.png"
 						        }
 						    }
 						}
@@ -190,7 +196,10 @@ public interface ProfileControllerV1Docs {
 
 	@Operation(
 		summary = "프로필 수정",
-		description = "JWT 토큰에서 사용자 ID를 추출하여 프로필을 수정합니다. Access Token이 필요합니다."
+		description = """
+			✅ API를 사용하려면 Access Token이 필요합니다. \n
+			JWT 토큰에서 사용자 ID를 추출하여 프로필을 수정합니다.
+			"""
 	)
 	@io.swagger.v3.oas.annotations.parameters.RequestBody(
 		description = "프로필 수정 정보",

--- a/src/main/java/com/debateseason_backend_v1/domain/user/controller/docs/UserControllerV1Docs.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/controller/docs/UserControllerV1Docs.java
@@ -1,10 +1,15 @@
 package com.debateseason_backend_v1.domain.user.controller.docs;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import com.debateseason_backend_v1.common.response.ApiResult;
+import com.debateseason_backend_v1.common.response.ErrorResponse;
+import com.debateseason_backend_v1.common.response.VoidApiResult;
+import com.debateseason_backend_v1.domain.user.controller.request.LogoutRequest;
 import com.debateseason_backend_v1.domain.user.controller.request.SocialLoginRequest;
 import com.debateseason_backend_v1.domain.user.service.response.LoginResponse;
+import com.debateseason_backend_v1.security.CustomUserDetails;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -12,16 +17,18 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @Tag(name = "User API", description = "로그인 관련 API")
 public interface UserControllerV1Docs {
 
 	@Operation(
-		summary = "소셜 로그인",
+		summary = "로그인",
 		description = """
-			소셜 타입과 식별자를 이용하여 로그인을 수행합니다.
-			첫 로그인(프로필 미등록)인 경우 profileStatus가 false,
+			소셜 타입과 식별자를 이용하여 로그인을 수행합니다. \n
+			첫 로그인(프로필 미등록)인 경우 profileStatus가 false, \n
 			프로필 등록 후 로그인의 경우 profileStatus가 true로 응답됩니다.
 			"""
 	)
@@ -52,7 +59,7 @@ public interface UserControllerV1Docs {
 							{
 							    "status": 200,
 							    "code": "SUCCESS",
-							    "message": "소셜 로그인 성공",
+							    "message": "로그인을 성공했습니다.",
 							    "data": {
 							        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
 							        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
@@ -69,7 +76,7 @@ public interface UserControllerV1Docs {
 							{
 							    "status": 200,
 							    "code": "SUCCESS",
-							    "message": "소셜 로그인 성공",
+							    "message": "로그인을 성공했습니다.",
 							    "data": {
 							        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
 							        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
@@ -99,6 +106,184 @@ public interface UserControllerV1Docs {
 			)
 		)
 	})
-	public ApiResult<?> socialLogin(@RequestBody SocialLoginRequest request);
+	public ApiResult<LoginResponse> login(@RequestBody SocialLoginRequest request);
 
+	@Operation(
+		summary = "로그아웃",
+		description = """
+			✅ API를 사용하려면 Access Token이 필요합니다. \n
+			API를 호출 시 Refresh Token을 무효화됩니다. \n
+			프론트엔드 단에서는 Access Token과 Refresh Token을 모두 삭제해야 합니다.
+			"""
+	)
+	@SecurityRequirement(name = "Bearer Authentication")
+	@io.swagger.v3.oas.annotations.parameters.RequestBody(
+		content = @Content(
+			mediaType = "application/json",
+			schema = @Schema(implementation = LogoutRequest.class)
+		)
+	)
+	@ApiResponses(value = {
+		@ApiResponse(
+			responseCode = "200",
+			description = "로그아웃 성공",
+			content = @Content(
+				mediaType = "application/json",
+				schema = @Schema(implementation = VoidApiResult.class),
+				examples = @ExampleObject(
+					value = """
+						{
+						    "status": 200,
+						    "code": "SUCCESS",
+						    "message": "로그아웃을 성공했습니다."
+						}
+						"""
+				)
+			)
+		),
+		@ApiResponse(
+			responseCode = "401",
+			description = "인증 실패",
+			content = @Content(
+				mediaType = "application/json",
+				schema = @Schema(
+					oneOf = {
+						ErrorResponse.class
+					}
+				),
+				examples = {
+					@ExampleObject(
+						name = "ExpiredAccessToken",
+						summary = "만료된 Access Token",
+						value = """
+							{
+							    "status": 401,
+							    "code": "EXPIRED_ACCESS_TOKEN",
+							    "message": "Access Token이 만료되었습니다. 다시 로그인해주세요."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "ExpiredRefreshToken",
+						summary = "만료된 Refresh Token",
+						value = """
+							{
+							    "status": 401,
+							    "code": "EXPIRED_REFRESH_TOKEN",
+							    "message": "Refresh Token이 만료되었습니다. 다시 로그인해주세요."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "InvalidAccessToken",
+						summary = "유효하지 않은 Access Token",
+						value = """
+							{
+							    "status": 401,
+							    "code": "INVALID_ACCESS_TOKEN",
+							    "message": "유효하지 않은 Access Token 입니다."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "InvalidRefreshToken",
+						summary = "유효하지 않은 Refresh Token",
+						value = """
+							{
+							    "status": 401,
+							    "code": "INVALID_REFRESH_TOKEN",
+							    "message": "유효하지 않은 Refresh Token 입니다."
+							}
+							"""
+					)
+				}
+			)
+		)
+	})
+	VoidApiResult logout(@Valid @RequestBody LogoutRequest request,
+		@AuthenticationPrincipal CustomUserDetails userDetails);
+
+	@Operation(
+		summary = "회원 탈퇴",
+		description = """
+			✅ API를 사용하려면 Access Token이 필요합니다. \n
+			회원 탈퇴를 수행합니다. \n
+			탈퇴 시 사용자는 soft delate 되며, 5일 후 사용자의 개인정보가 익명화 처리가 진행됩니다. \n
+			탈퇴 후에는 Refresh Token이 무효화됩니다. \n
+			프론트엔드 단에서는 Access Token과 Refresh Token을 모두 삭제해야 합니다.
+			"""
+	)
+	@SecurityRequirement(name = "Bearer Authentication")
+	@ApiResponses(value = {
+		@ApiResponse(
+			responseCode = "200",
+			description = "회원 탈퇴 성공",
+			content = @Content(
+				mediaType = "application/json",
+				schema = @Schema(implementation = VoidApiResult.class),
+				examples = @ExampleObject(
+					value = """
+						{
+						    "status": 200,
+						    "code": "SUCCESS",
+						    "message": "회원 탈퇴가 완료되었습니다."
+						}
+						"""
+				)
+			)
+		),
+		@ApiResponse(
+			responseCode = "401",
+			description = "인증 실패",
+			content = @Content(
+				mediaType = "application/json",
+				schema = @Schema(
+					oneOf = {
+						ErrorResponse.class
+					}
+				),
+				examples = {
+					@ExampleObject(
+						name = "ExpiredAccessToken",
+						summary = "만료된 Access Token",
+						value = """
+							{
+							    "status": 401,
+							    "code": "EXPIRED_ACCESS_TOKEN",
+							    "message": "Access Token이 만료되었습니다. 다시 로그인해주세요."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "InvalidAccessToken",
+						summary = "유효하지 않은 Access Token",
+						value = """
+							{
+							    "status": 401,
+							    "code": "INVALID_ACCESS_TOKEN",
+							    "message": "유효하지 않은 Access Token 입니다."
+							}
+							"""
+					)
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = "존재하지 않는 회원",
+			content = @Content(
+				mediaType = "application/json",
+				examples = @ExampleObject(
+					value = """
+						{
+						    "status": 404,
+						    "code": "USER_NOT_FOUND",
+						    "message": "사용자를 찾을 수 없습니다."
+						}
+						"""
+				)
+			)
+		)
+	})
+	VoidApiResult withdraw(@AuthenticationPrincipal CustomUserDetails userDetails);
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/user/controller/docs/UserControllerV1Docs.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/controller/docs/UserControllerV1Docs.java
@@ -94,15 +94,30 @@ public interface UserControllerV1Docs {
 			description = "지원하지 않는 소셜 요청",
 			content = @Content(
 				mediaType = "application/json",
-				examples = @ExampleObject(
-					value = """
-						{
-						    "status": 400,
-						    "code": "NOT_SUPPORTED_SOCIAL_TYPE",
-						    "message": "지원하지 않는 소셜 타입입니다"
-						}
-						"""
-				)
+				examples = {
+					@ExampleObject(
+						name = "MissingSingleRequiredValue",
+						summary = "필수 입력값에 빈 문자열 입력",
+						value = """
+							{
+							    "status": 400,
+							    "code": "MISSING_REQUIRED_VALUE",
+							    "message": "소셜 고유 ID는 필수입니다."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "NotSupportedSocialType",
+						summary = "지원하지 않는 소셜 타입",
+						value = """
+							{
+							    "status": 400,
+							    "code": "NOT_SUPPORTED_SOCIAL_TYPE",
+							    "message": "지원하지 않는 소셜 타입입니다"
+							}
+							"""
+					)
+				}
 			)
 		)
 	})
@@ -139,6 +154,26 @@ public interface UserControllerV1Docs {
 						}
 						"""
 				)
+			)
+		),
+		@ApiResponse(
+			responseCode = "400",
+			description = "잘못된 요청",
+			content = @Content(
+				mediaType = "application/json",
+				examples = {
+					@ExampleObject(
+						name = "MissingSingleRequiredValue",
+						summary = "필수 입력값에 빈 문자열 입력",
+						value = """
+							{
+							    "status": 400,
+							    "code": "MISSING_REQUIRED_VALUE",
+							    "message": "Refresh Token은 필수입니다."
+							}
+							"""
+					)
+				}
 			)
 		),
 		@ApiResponse(

--- a/src/main/java/com/debateseason_backend_v1/domain/user/controller/request/LogoutRequest.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/controller/request/LogoutRequest.java
@@ -10,7 +10,7 @@ public record LogoutRequest(
 	@Schema(description = "리프레시 토큰",
 		example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
 		format = "jwt")
-	@NotBlank(message = "리프레시 토큰은 필수입니다.")
+	@NotBlank(message = "Refresh Token은 필수입니다.")
 	String refreshToken
 ) {
 

--- a/src/main/java/com/debateseason_backend_v1/domain/user/controller/request/SocialLoginRequest.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/controller/request/SocialLoginRequest.java
@@ -11,7 +11,7 @@ import jakarta.validation.constraints.NotNull;
 public record SocialLoginRequest(
 
 	@Schema(description = "사용자 고유 식별자", example = "1323412")
-	@NotBlank(message = "외부 ID는 필수입니다.")
+	@NotBlank(message = "소셜 고유 ID는 필수입니다.")
 	String identifier,
 
 	@Schema(description = "로그인 요청 소셜 타입", example = "kakao")

--- a/src/main/java/com/debateseason_backend_v1/domain/user/enums/GenderType.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/enums/GenderType.java
@@ -16,7 +16,7 @@ public enum GenderType {
 
 	MALE("남성"),
 	FEMALE("여성"),
-	NO_RESPONSE("무응답");
+	UNDEFINED("무응답");
 
 	private final String description;
 

--- a/src/main/java/com/debateseason_backend_v1/domain/user/scheduler/UserScheduler.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/scheduler/UserScheduler.java
@@ -1,0 +1,55 @@
+package com.debateseason_backend_v1.domain.user.scheduler;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.debateseason_backend_v1.common.component.UuidShortener;
+import com.debateseason_backend_v1.domain.repository.ProfileRepository;
+import com.debateseason_backend_v1.domain.repository.UserRepository;
+import com.debateseason_backend_v1.domain.repository.entity.Profile;
+import com.debateseason_backend_v1.domain.repository.entity.User;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserScheduler {
+
+	private final UuidShortener uuidShortener;
+	private final UserRepository userRepository;
+	private final ProfileRepository profileRepository;
+
+	@Scheduled(cron = "0 0 0 * * *") // 매일 자정 실행
+	@Transactional
+	public void anonymizeExpiredUsers() {
+		log.info("탈퇴 회원 익명화 처리 시작: {}", LocalDateTime.now());
+
+		LocalDateTime cutoffDate = LocalDateTime.now().minusDays(5);
+
+		List<User> expiredUsers = userRepository.findByIsDeletedTrueAndUpdatedAtBefore(cutoffDate);
+
+		for (User user : expiredUsers) {
+			String uuid = uuidShortener.shortenUuid();
+			log.info("회원 ID: {} 익명화 처리 중", user.getId());
+
+			user.anonymize(uuid);
+
+			Profile profile = profileRepository.findByUserId(user.getId())
+				.orElse(null);
+
+			if (profile != null) {
+				profile.anonymize("탈퇴회원#" + uuid);
+				log.info("회원 ID: {}의 프로필 익명화 완료", user.getId());
+			}
+		}
+
+		log.info("총 {}명의 탈퇴 회원 익명화 처리 완료", expiredUsers.size());
+	}
+
+}

--- a/src/main/java/com/debateseason_backend_v1/domain/user/service/UserServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/service/UserServiceV1.java
@@ -63,16 +63,16 @@ public class UserServiceV1 {
 	@Transactional
 	public void logout(LogoutServiceRequest request) {
 
+		if (!refreshTokenRepository.existsByToken(request.refreshToken())) {
+			throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+		}
+
 		if (jwtUtil.isExpired(request.refreshToken())) {
-			throw new CustomException(ErrorCode.TOKEN_EXPIRED);
+			throw new CustomException(ErrorCode.EXPIRED_REFRESH_TOKEN);
 		}
 
 		if (jwtUtil.getTokenType(request.refreshToken()) != TokenType.REFRESH) {
-			throw new CustomException(ErrorCode.INVALID_TOKEN);
-		}
-
-		if (!refreshTokenRepository.existsByToken(request.refreshToken())) {
-			throw new CustomException(ErrorCode.INVALID_TOKEN);
+			throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
 		}
 
 		refreshTokenRepository.deleteByToken(request.refreshToken());

--- a/src/main/java/com/debateseason_backend_v1/domain/user/service/UserServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/service/UserServiceV1.java
@@ -41,6 +41,10 @@ public class UserServiceV1 {
 			)
 			.orElseGet(() -> createNewUser(request));
 
+		if (user.isDeleted()) {
+			user.restore();
+		}
+
 		String newAccessToken = jwtUtil.createAccessToken(user.getId());
 		String newRefreshToken = jwtUtil.createRefreshToken(user.getId());
 

--- a/src/main/java/com/debateseason_backend_v1/domain/user/service/UserServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/service/UserServiceV1.java
@@ -74,6 +74,17 @@ public class UserServiceV1 {
 		refreshTokenRepository.deleteByToken(request.refreshToken());
 	}
 
+	@Transactional
+	public void withdraw(Long userId) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		user.withdraw();
+
+		refreshTokenRepository.deleteAllByUserId(user.getId());
+	}
+
 	private User createNewUser(SocialLoginServiceRequest request) {
 
 		User user = User.builder()

--- a/src/main/java/com/debateseason_backend_v1/security/error/JwtAuthenticationErrorHandler.java
+++ b/src/main/java/com/debateseason_backend_v1/security/error/JwtAuthenticationErrorHandler.java
@@ -28,7 +28,7 @@ public class JwtAuthenticationErrorHandler {
 
 		ErrorResponse errorResponse = ErrorResponse.of(
 			HttpStatus.UNAUTHORIZED,
-			ErrorCode.TOKEN_EXPIRED
+			ErrorCode.EXPIRED_ACCESS_TOKEN
 		);
 
 		writeErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
@@ -40,7 +40,7 @@ public class JwtAuthenticationErrorHandler {
 
 		ErrorResponse errorResponse = ErrorResponse.of(
 			HttpStatus.UNAUTHORIZED,
-			ErrorCode.INVALID_TOKEN
+			ErrorCode.INVALID_ACCESS_TOKEN
 		);
 		writeErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
 	}

--- a/src/test/java/com/debateseason_backend_v1/domain/user/scheduler/UserSchedulerTest.java
+++ b/src/test/java/com/debateseason_backend_v1/domain/user/scheduler/UserSchedulerTest.java
@@ -1,0 +1,163 @@
+package com.debateseason_backend_v1.domain.user.scheduler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.debateseason_backend_v1.common.component.UuidShortener;
+import com.debateseason_backend_v1.domain.repository.ProfileRepository;
+import com.debateseason_backend_v1.domain.repository.UserRepository;
+import com.debateseason_backend_v1.domain.repository.entity.Profile;
+import com.debateseason_backend_v1.domain.repository.entity.User;
+import com.debateseason_backend_v1.domain.user.enums.AgeRangeType;
+import com.debateseason_backend_v1.domain.user.enums.GenderType;
+import com.debateseason_backend_v1.domain.user.enums.SocialType;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class UserSchedulerTest {
+
+	@Mock
+	private UuidShortener uuidShortener;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private ProfileRepository profileRepository;
+
+	@InjectMocks
+	private UserScheduler userScheduler;
+
+	@Test
+	@DisplayName("탈퇴 후 5일이 지난 회원들이 정상적으로 익명화된다")
+	void anonymizeExpiredUsersSuccessfully() {
+		// given
+		LocalDateTime now = LocalDateTime.of(2024, 1, 21, 0, 0);
+		LocalDateTime cutoffDate = now.minusDays(5);
+
+		User user1 = createUser(1L, "old-id-1", true, now.minusDays(6));
+		User user2 = createUser(2L, "old-id-2", true, now.minusDays(7));
+		List<User> expiredUsers = Arrays.asList(user1, user2);
+
+		Profile profile1 = createProfile(1L, 1L, "old-nickname-1");
+		Profile profile2 = createProfile(2L, 2L, "old-nickname-2");
+
+		when(userRepository.findByIsDeletedTrueAndUpdatedAtBefore(any(LocalDateTime.class)))
+			.thenReturn(expiredUsers);
+		when(profileRepository.findByUserId(1L)).thenReturn(Optional.of(profile1));
+		when(profileRepository.findByUserId(2L)).thenReturn(Optional.of(profile2));
+		when(uuidShortener.shortenUuid())
+			.thenReturn("short-1")
+			.thenReturn("short-2");
+
+		// when
+		try (MockedStatic<LocalDateTime> mockedStatic = mockStatic(LocalDateTime.class)) {
+			mockedStatic.when(LocalDateTime::now).thenReturn(now);
+			userScheduler.anonymizeExpiredUsers();
+		}
+
+		// then
+		verify(userRepository).findByIsDeletedTrueAndUpdatedAtBefore(cutoffDate);
+		verify(profileRepository, times(2)).findByUserId(any(Long.class));
+
+		assertAll(
+			() -> assertEquals("short-1", user1.getIdentifier()),
+			() -> assertEquals("short-2", user2.getIdentifier()),
+			() -> assertEquals("탈퇴회원#short-1", profile1.getNickname()),
+			() -> assertEquals("탈퇴회원#short-2", profile2.getNickname()),
+			() -> assertEquals(GenderType.UNDEFINED, profile1.getGender()),
+			() -> assertEquals(GenderType.UNDEFINED, profile2.getGender())
+		);
+	}
+
+	@Test
+	@DisplayName("프로필이 없는 탈퇴 회원도 정상적으로 익명화된다")
+	void anonymizeExpiredUsersWithoutProfile() {
+		// given
+		LocalDateTime now = LocalDateTime.of(2024, 1, 21, 0, 0);
+		LocalDateTime cutoffDate = now.minusDays(5);
+
+		User user = createUser(1L, "old-id", true, now.minusDays(6));
+		List<User> expiredUsers = Collections.singletonList(user);
+
+		when(userRepository.findByIsDeletedTrueAndUpdatedAtBefore(any(LocalDateTime.class)))
+			.thenReturn(expiredUsers);
+		when(profileRepository.findByUserId(1L)).thenReturn(Optional.empty());
+		when(uuidShortener.shortenUuid()).thenReturn("short-uuid");
+
+		// when
+		try (MockedStatic<LocalDateTime> mockedStatic = mockStatic(LocalDateTime.class)) {
+			mockedStatic.when(LocalDateTime::now).thenReturn(now);
+			userScheduler.anonymizeExpiredUsers();
+		}
+
+		// then
+		verify(userRepository).findByIsDeletedTrueAndUpdatedAtBefore(cutoffDate);
+		verify(profileRepository).findByUserId(1L);
+		assertEquals("short-uuid", user.getIdentifier());
+	}
+
+	@Test
+	@DisplayName("탈퇴 후 5일이 지나지 않은 회원은 익명화되지 않는다")
+	void doNotAnonymizeRecentlyDeletedUsers() {
+		// given
+		LocalDateTime now = LocalDateTime.of(2024, 1, 21, 0, 0);
+		LocalDateTime cutoffDate = now.minusDays(5);
+
+		when(userRepository.findByIsDeletedTrueAndUpdatedAtBefore(any(LocalDateTime.class)))
+			.thenReturn(Collections.emptyList());
+
+		// when
+		try (MockedStatic<LocalDateTime> mockedStatic = mockStatic(LocalDateTime.class)) {
+			mockedStatic.when(LocalDateTime::now).thenReturn(now);
+			userScheduler.anonymizeExpiredUsers();
+		}
+
+		// then
+		verify(userRepository).findByIsDeletedTrueAndUpdatedAtBefore(cutoffDate);
+		verify(profileRepository, never()).findByUserId(any(Long.class));
+		verify(uuidShortener, never()).shortenUuid();
+	}
+
+	private User createUser(Long id, String identifier, boolean isDeleted, LocalDateTime updatedAt) {
+		User user = User.builder()
+			.socialType(SocialType.KAKAO)
+			.externalId(identifier)
+			.build();
+
+		ReflectionTestUtils.setField(user, "id", id);
+		ReflectionTestUtils.setField(user, "isDeleted", isDeleted);
+		ReflectionTestUtils.setField(user, "updatedAt", updatedAt);
+
+		return user;
+	}
+
+	private Profile createProfile(Long id, Long userId, String nickname) {
+		Profile profile = Profile.builder()
+			.userId(userId)
+			.nickname(nickname)
+			.gender(GenderType.MALE)
+			.ageRange(AgeRangeType.TWENTIES)
+			.build();
+
+		ReflectionTestUtils.setField(profile, "id", id);
+
+		return profile;
+	}
+}

--- a/src/test/java/com/debateseason_backend_v1/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/debateseason_backend_v1/security/jwt/JwtAuthenticationFilterTest.java
@@ -85,7 +85,7 @@ class JwtAuthenticationFilterTest {
 				.andExpect(status().isUnauthorized())
 				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 				.andExpect(jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.value()))
-				.andExpect(jsonPath("$.code").value(ErrorCode.TOKEN_EXPIRED.name()))
+				.andExpect(jsonPath("$.code").value(ErrorCode.EXPIRED_ACCESS_TOKEN.name()))
 				.andDo(print());
 		}
 
@@ -103,7 +103,7 @@ class JwtAuthenticationFilterTest {
 				.andExpect(status().isUnauthorized())
 				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 				.andExpect(jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.value()))
-				.andExpect(jsonPath("$.code").value(ErrorCode.INVALID_TOKEN.name()))
+				.andExpect(jsonPath("$.code").value(ErrorCode.INVALID_ACCESS_TOKEN.name()))
 				.andDo(print());
 		}
 
@@ -119,7 +119,7 @@ class JwtAuthenticationFilterTest {
 				.andExpect(status().isUnauthorized())
 				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 				.andExpect(jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.value()))
-				.andExpect(jsonPath("$.code").value(ErrorCode.INVALID_TOKEN.name()))
+				.andExpect(jsonPath("$.code").value(ErrorCode.INVALID_ACCESS_TOKEN.name()))
 				.andDo(print());
 
 			// JWT 검증이 실행되지 않았음을 확인


### PR DESCRIPTION
## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
회원탈퇴 기능 구현을 했습니다.

## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
1. 회원탈퇴 기능 구현을 했습니다.
soft delate 방식의 회원탈퇴 기능을 구현했습니다. 회원 탈퇴 5일 후 개인정보(소셜 제공자 ID, 닉네임, 성별)를 익명화합니다.
매일 자정에 익명화 스케줄러가 작동되며 익명화는 아래와 같은 방법으로 고유한 값으로 대체됩니다.
<img width="488" alt="스크린샷 2025-01-21 오후 6 18 39" src="https://github.com/user-attachments/assets/b7918f69-ca82-47e6-be55-faaf0f3ab7c2" />

soft delate를 선택한 이유는 탈퇴한 사용자가 남긴 데이터를 활용하기 위한 요구사항 때문입니다.

2. 스웨거 문서를 업데이트 했습니다.
스웨거 문서에 Auth, User, Profile API에 예외 처리 응답을 추가했습니다.

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->


