### PR TITLE
feat: 프로필 컬러 등록 추가

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Profile.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Profile.java
@@ -1,7 +1,6 @@
 package com.debateseason_backend_v1.domain.repository.entity;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -38,6 +37,9 @@ public class Profile {
 	@Column(name = "user_id")
 	private Long userId;
 
+	@Column(name = "profile_coler")
+	private String profileColor;
+
 	@Column(name = "nickname", unique = true)
 	private String nickname;
 
@@ -54,26 +56,22 @@ public class Profile {
 	private LocalDateTime updatedAt;
 
 	@Builder
-	private Profile(Long userId, String nickname, GenderType gender, AgeRangeType ageRange
+	private Profile(Long userId, String profileColor, String nickname, GenderType gender, AgeRangeType ageRange
 	) {
 
 		this.userId = userId;
+		this.profileColor = profileColor;
 		this.nickname = nickname;
 		this.gender = gender;
 		this.ageRange = ageRange;
 	}
 
-	public void update(String nickname, GenderType gender, AgeRangeType ageRange) {
+	public void update(String profileColor, String nickname, GenderType gender, AgeRangeType ageRange) {
 
-		if (!Objects.equals(nickname, this.nickname)) {
-			this.nickname = nickname;
-		}
-		if (!Objects.equals(gender, this.gender)) {
-			this.gender = gender;
-		}
-		if (!Objects.equals(ageRange, this.ageRange)) {
-			this.ageRange = ageRange;
-		}
+		this.profileColor = profileColor;
+		this.nickname = nickname;
+		this.gender = gender;
+		this.ageRange = ageRange;
 	}
 
 	public void anonymize(String anonymousNickname) {

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Profile.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Profile.java
@@ -37,7 +37,7 @@ public class Profile {
 	@Column(name = "user_id")
 	private Long userId;
 
-	@Column(name = "profile_coler")
+	@Column(name = "profile_color")
 	private String profileColor;
 
 	@Column(name = "nickname", unique = true)

--- a/src/main/java/com/debateseason_backend_v1/domain/user/controller/request/ProfileRegisterRequest.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/controller/request/ProfileRegisterRequest.java
@@ -10,6 +10,9 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "프로필 등록 요청 DTO")
 public record ProfileRegisterRequest(
+	@Schema(description = "프로필 컬러", example = "RED")
+	String profileColor,
+
 	@Schema(description = "사용자 닉네임", example = "토론왕")
 	@NotBlank(message = "닉네임은 필수입니다.")
 	String nickname,
@@ -31,6 +34,7 @@ public record ProfileRegisterRequest(
 
 		return ProfileRegisterServiceRequest.builder()
 			.userId(userId)
+			.profileColor(profileColor)
 			.nickname(nickname)
 			.communityId(communityId)
 			.gender(gender)

--- a/src/main/java/com/debateseason_backend_v1/domain/user/controller/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/controller/request/ProfileUpdateRequest.java
@@ -10,6 +10,9 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "프로필 수정 요청 DTO")
 public record ProfileUpdateRequest(
+	@Schema(description = "사용자 색상", example = "RED")
+	String profileColor,
+
 	@Schema(description = "사용자 닉네임", example = "토론왕")
 	@NotBlank(message = "닉네임은 필수입니다.")
 	String nickname,
@@ -31,6 +34,7 @@ public record ProfileUpdateRequest(
 
 		return ProfileUpdateServiceRequest.builder()
 			.userId(userId)
+			.profileColor(profileColor)
 			.nickname(nickname)
 			.communityId(communityId)
 			.gender(gender)

--- a/src/main/java/com/debateseason_backend_v1/domain/user/service/ProfileServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/service/ProfileServiceV1.java
@@ -40,6 +40,7 @@ public class ProfileServiceV1 {
 
 		Profile profile = Profile.builder()
 			.userId(request.userId())
+			.profileColor(request.profileColor())
 			.nickname(request.nickname())
 			.gender(request.gender())
 			.ageRange(request.ageRange())
@@ -83,7 +84,7 @@ public class ProfileServiceV1 {
 		}
 		communityValidator.validate(request.communityId());
 
-		profile.update(request.nickname(), request.gender(), request.ageRange());
+		profile.update(request.profileColor(), request.nickname(), request.gender(), request.ageRange());
 
 		ProfileCommunity profileCommunity = profileCommunityRepository.getByProfileId(profile.getId());
 		profileCommunity.updateCommunity(request.communityId());

--- a/src/main/java/com/debateseason_backend_v1/domain/user/service/request/ProfileRegisterServiceRequest.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/service/request/ProfileRegisterServiceRequest.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 @Builder
 public record ProfileRegisterServiceRequest(
 	Long userId,
+	String profileColor,
 	String nickname,
 	Long communityId,
 	GenderType gender,

--- a/src/main/java/com/debateseason_backend_v1/domain/user/service/request/ProfileUpdateServiceRequest.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/service/request/ProfileUpdateServiceRequest.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 @Builder
 public record ProfileUpdateServiceRequest(
 	Long userId,
+	String profileColor,
 	String nickname,
 	Long communityId,
 	GenderType gender,

--- a/src/main/java/com/debateseason_backend_v1/domain/user/service/response/ProfileResponse.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/service/response/ProfileResponse.java
@@ -9,6 +9,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "내 프로필 조회 응답")
 public record ProfileResponse(
+	@Schema(description = "프로필 컬러", example = "RED")
+	String profileColor,
+
 	@Schema(description = "닉네임", example = "토론왕")
 	String nickname,
 
@@ -25,6 +28,7 @@ public record ProfileResponse(
 	public static ProfileResponse of(Profile profile, Community community) {
 
 		return new ProfileResponse(
+			profile.getProfileColor(),
 			profile.getNickname(),
 			profile.getGender(),
 			profile.getAgeRange(),

--- a/src/main/java/com/debateseason_backend_v1/domain/user/service/response/ProfileResponse.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/service/response/ProfileResponse.java
@@ -9,8 +9,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "내 프로필 조회 응답")
 public record ProfileResponse(
-	@Schema(description = "프로필 컬러", example = "RED")
-	String profileColor,
+	// @Schema(description = "프로필 컬러", example = "RED")
+	// String profileColor,
 
 	@Schema(description = "닉네임", example = "토론왕")
 	String nickname,
@@ -28,7 +28,7 @@ public record ProfileResponse(
 	public static ProfileResponse of(Profile profile, Community community) {
 
 		return new ProfileResponse(
-			profile.getProfileColor(),
+			// profile.getProfileColor(),
 			profile.getNickname(),
 			profile.getGender(),
 			profile.getAgeRange(),


### PR DESCRIPTION
## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
프론트에서 넘겨주는 프로필 컬러를 저장하고 수정할 수 있게 수정

## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
1. 프로필을 등록할 때 프로필 컬러를 등록할 수 있게 수정함.
프로필 컬러를 String 값으로 받음. 추후 타입 안정성을 원한다면 enum으로 변경

2. 프로필을 수정할 때 프로필 컬러를 등록할 수 있게 수정함.

3. 프로필 응답 dto는 이전 값 그대로 사용
프론트엔드 호환성을 위해 변경하지 않았습니다. 추후 변경 필요

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->

