### PR TITLE
infra: 스웨거 요청 베이스 URL 환경별 분리

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/DebateSeasonBackendV1Application.java
+++ b/src/main/java/com/debateseason_backend_v1/DebateSeasonBackendV1Application.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.servers.Server;
 
 @EnableScheduling
-@OpenAPIDefinition(servers = {@Server(url = "https://debate-season.click",description = "Swagger https 프로토콜 적용")})
+@OpenAPIDefinition(servers = {@Server(url = "${swagger-base-url}", description = "Swagger https 프로토콜 적용")})
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class) // 자동으로 날짜 입력활성화
 public class DebateSeasonBackendV1Application {
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -67,4 +67,8 @@ logging:
 server:
   servlet:
     context-path: /dev
+
   port: 80
+
+# 환경별로 스웨거 요청 분리
+swagger-base-url: ${SWAGGER_BASE_URL}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -71,4 +71,4 @@ server:
   port: 80
 
 # 환경별로 스웨거 요청 분리
-swagger-base-url: ${SWAGGER_BASE_URL}
+swagger-base-url: "https://debate-season.click/dev"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -56,4 +56,4 @@ jwt:
   refresh-token:
     expire-time: 86400000 # 24시간
 
-swagger-base-url: http://localhost:8080
+swagger-base-url: "http://localhost:8080"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -55,3 +55,5 @@ jwt:
     expire-time: 6000000   # 10분
   refresh-token:
     expire-time: 86400000 # 24시간
+
+swagger-base-url: http://localhost:8080

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -79,4 +79,8 @@ logging:
 server:
   servlet:
     context-path: /prod
+
   port: 80
+
+# 환경별로 스웨거 요청 분리
+swagger-base-url: ${SWAGGER_BASE_URL}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -83,4 +83,4 @@ server:
   port: 80
 
 # 환경별로 스웨거 요청 분리
-swagger-base-url: ${SWAGGER_BASE_URL}
+swagger-base-url: "https://debate-season.click/prod"


### PR DESCRIPTION
## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
스웨거에서 요청을 보낼 때 사용하는 베이스 URL을 동적으로 사용할 수 있게 변경했습니다.

## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
### 1. 환경변수를 이용한 스웨거 베이스 URL 동적 변경

**<기존 코드>**
```JAVA
@EnableScheduling
@OpenAPIDefinition(servers = {@Server(url = "https://debate-season.click", description = "Swagger https 프로토콜 적용")})
@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
public class DebateSeasonBackendV1Application {

	public static void main(String[] args) {
		SpringApplication.run(DebateSeasonBackendV1Application.class, args);
	}

}
```
환경분리를 하던 중 기존 스웨거 베이스 URL이 하드 코딩되어 있어 로컬 환경, 개발 환경, 운영 환경 모두 `https://debate-season.click` 경로로 요청이 보내지는 현상을 발견했습니다.

이 문제를 해결하기 위해 각 환경별로 스웨거 베이스 URL 환경 변수를 만들었고 이를 동적으로 가져와 사용하도록 수정했습니다.


**<수정된 코드>**
```JAVA
@EnableScheduling
// 수정된 부분
@OpenAPIDefinition(servers = {@Server(url = "${swagger-base-url}", description = "Swagger https 프로토콜 적용")}) 
@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
public class DebateSeasonBackendV1Application {

	public static void main(String[] args) {
		SpringApplication.run(DebateSeasonBackendV1Application.class, args);
	}

}
```


**<환경 변수 설정>**
- 로컬 환경
```YMAL
# application-local.yml
swagger-base-url: "http://localhost:8080"
```


- 개발 환경
```YMAL
# application-dev.yml
swagger-base-url: "https://debate-season.click/dev"
```


- 운영 환경
```YMAL
# application-prod.yml
swagger-base-url: "https://debate-season.click/prod"
```


## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->

