### PR TITLE
feat: stomp 연결 엔드포인트 환경분리

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/config/WebSocketConfig.java
+++ b/src/main/java/com/debateseason_backend_v1/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.debateseason_backend_v1.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -13,6 +14,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    @Value("${stomp-connect-url}")
+    private String stompConnectUrl;
+
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/topic"); //sub
@@ -21,7 +25,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry register) {
-        register.addEndpoint("/ws-stomp")
+        register.addEndpoint(stompConnectUrl)
             .setAllowedOrigins("*");
             // .withSockJS();
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -72,3 +72,6 @@ server:
 
 # 환경별로 스웨거 요청 분리
 swagger-base-url: "https://debate-season.click/dev"
+
+#stomp 연결 환경분리
+stomp-connect-url: "/ws-stomp/dev"

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -74,4 +74,4 @@ server:
 swagger-base-url: "https://debate-season.click/dev"
 
 #stomp 연결 환경분리
-stomp-connect-url: "/ws-stomp/dev"
+stomp-connect-url: "/dev/ws-stomp"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -57,3 +57,6 @@ jwt:
     expire-time: 86400000 # 24시간
 
 swagger-base-url: "http://localhost:8080"
+
+#stomp 연결 환경분리
+stomp-connect-url: "/ws-stomp/local"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -59,4 +59,4 @@ jwt:
 swagger-base-url: "http://localhost:8080"
 
 #stomp 연결 환경분리
-stomp-connect-url: "/ws-stomp/local"
+stomp-connect-url: "/local/ws-stomp"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -86,4 +86,4 @@ server:
 swagger-base-url: "https://debate-season.click/prod"
 
 #stomp 연결 환경분리
-stomp-connect-url: "/ws-stomp/prod"
+stomp-connect-url: "/prod/ws-stomp"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -84,3 +84,6 @@ server:
 
 # 환경별로 스웨거 요청 분리
 swagger-base-url: "https://debate-season.click/prod"
+
+#stomp 연결 환경분리
+stomp-connect-url: "/ws-stomp/prod"

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -40,4 +40,4 @@ jwt:
     expire-time: 86400000 # 24시간
 
 
-    stomp-connect-url: "/test/ws-stomp"
+stomp-connect-url: "/test/ws-stomp"

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -38,3 +38,6 @@ jwt:
     expire-time: 6000000   # 10분
   refresh-token:
     expire-time: 86400000 # 24시간
+
+
+    stomp-connect-url: "/test/ws-stomp"


### PR DESCRIPTION
## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
WebSocket 연결 엔드포인트를 환경(dev/prod/local)별로 분리하여 구성

## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
1. application-dev.yml, application-prod.yml에 stomp-connect-url 설정 추가
- dev: "/dev/ws-stomp"
- prod: "/prod/ws-stomp"
- local: "/local/ws-stomp"
2. WebSocketConfig에서 @Value를 통해 stomp-connect-url 값을 주입받도록 수정
3. 환경별로 다른 WebSocket 엔드포인트 적용

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->
WebSocket 연결 시 환경(dev/prod/local)에 따라 다른 엔드포인트로 연결됩니다
dev 환경: debate-season.click/dev/ws-stomp
prod 환경: debate-season.click/prod/ws-stomp
local 환경  localhost:8080/local/ws-stomp

