### PR TITLE
fix: SecurityPathMatcher 환경별 URI 경로 처리 추가

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/security/component/SecurityPathMatcher.java
+++ b/src/main/java/com/debateseason_backend_v1/security/component/SecurityPathMatcher.java
@@ -4,21 +4,37 @@ import static com.debateseason_backend_v1.config.WebSecurityConfig.*;
 
 import java.util.Arrays;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
 
-import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
-@RequiredArgsConstructor
 public class SecurityPathMatcher {
 
-	private final PathMatcher pathMatcher = new AntPathMatcher();
+	private final PathMatcher pathMatcher;
+	private final String contextPath;
+
+	public SecurityPathMatcher(@Value("${server.servlet.context-path:}") String contextPath) {
+		this.pathMatcher = new AntPathMatcher();
+		this.contextPath = contextPath;
+	}
 
 	public boolean isPublicUrl(String requestURI) {
+
+		String pathWithoutContext = requestURI;
+		if (!contextPath.isEmpty() && requestURI.startsWith(contextPath)) {
+			pathWithoutContext = requestURI.substring(contextPath.length());
+		}
+
+		// 최종 값을 final 변수에 할당
+		final String finalPath = pathWithoutContext;
+
 		return Arrays.stream(PUBLIC_URLS)
-			.anyMatch(pattern -> pathMatcher.match(pattern, requestURI));
+			.anyMatch(pattern -> pathMatcher.match(pattern, finalPath));
 	}
 
 }


### PR DESCRIPTION
## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
SecurityPathMatcher 개발/운영 URI 적용

## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
### 1. SecurityPathMatcher 개발/운영 URI 적용
- SecurityPathMatcher가 개발/운영 환경의 URI를 처리 할 수 있도록 함.
- 이 처리를 하지 않으면 스프링 시큐리티 필터를 통과를 못하는 이슈가 발생
- 로컬은 context-path가 붙지 않아 문제가 없었지만 개발/운영 환경은 context-path가 붙어서 문제 발생

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->

