### PR TITLE
feat: 최신 약관 조희 기능 구현

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/config/WebSecurityConfig.java
+++ b/src/main/java/com/debateseason_backend_v1/config/WebSecurityConfig.java
@@ -34,6 +34,7 @@ public class WebSecurityConfig {
 		"/api/v1/users/login",
 		"/api/v2/users/login",
 		"/api/v1/auth/reissue",
+		"/api/v1/terms"
 	};
 
 	@Bean

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/TermsRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/TermsRepository.java
@@ -1,0 +1,20 @@
+package com.debateseason_backend_v1.domain.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.debateseason_backend_v1.domain.repository.entity.Terms;
+
+@Repository
+public interface TermsRepository extends JpaRepository<Terms, Long> {
+
+	@Query("SELECT t FROM Terms t " +
+		"WHERE (t.termsType, t.version) IN " +
+		"(SELECT t2.termsType, MAX(t2.version) FROM Terms t2 GROUP BY t2.termsType)"
+	)
+	Optional<List<Terms>> findLatestTermsForAllTypes();
+}

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/UserTermsAgreementRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/UserTermsAgreementRepository.java
@@ -1,0 +1,10 @@
+package com.debateseason_backend_v1.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.debateseason_backend_v1.domain.repository.entity.UserTermsAgreement;
+
+@Repository
+public interface UserTermsAgreementRepository extends JpaRepository<UserTermsAgreement, Long> {
+}

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Terms.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Terms.java
@@ -1,0 +1,48 @@
+package com.debateseason_backend_v1.domain.repository.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.debateseason_backend_v1.domain.terms.enums.TermsType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "terms")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Terms {
+
+	@Id
+	@Column(name = "terms_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "terms_type")
+	private TermsType termsType;
+
+	@Column(name = "notion_url")
+	private String notionUrl;
+
+	private String version; // 1.0.0, 1.0.1, 1.1.0, ...
+
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/UserTermsAgreement.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/UserTermsAgreement.java
@@ -1,0 +1,57 @@
+package com.debateseason_backend_v1.domain.repository.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "user_terms_agreement")
+@EntityListeners(AuditingEntityListener.class)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserTermsAgreement {
+
+	@Id
+	@Column(name = "user_terms_agreement_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "terms_id", nullable = false)
+	private Terms terms;
+
+	@CreatedDate
+	@Column(name = "agreed_at", updatable = false)
+	private LocalDateTime agreedAt;
+
+	public static UserTermsAgreement create(User user, Terms terms) {
+		return UserTermsAgreement.builder()
+			.user(user)
+			.terms(terms)
+			.build();
+	}
+
+}

--- a/src/main/java/com/debateseason_backend_v1/domain/terms/controller/TermsControllerV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/terms/controller/TermsControllerV1.java
@@ -1,0 +1,37 @@
+package com.debateseason_backend_v1.domain.terms.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.debateseason_backend_v1.common.response.ApiResult;
+import com.debateseason_backend_v1.domain.terms.service.TermsServiceV1;
+import com.debateseason_backend_v1.domain.terms.service.response.LatestTermsResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/terms")
+public class TermsControllerV1 {
+
+	private final TermsServiceV1 termsService;
+
+	@GetMapping
+	public ApiResult<List<LatestTermsResponse>> getLatestTerms() {
+
+		List<LatestTermsResponse> latestTerms = termsService.getLatestTerms();
+
+		return ApiResult.success(
+			"최신 약관 목록 조회가 완료되었습니다.",
+			latestTerms
+		);
+	}
+
+	// TODO: 내 약관 동의일자 조회 API
+
+	// TODO: 약관 동의 API
+
+}

--- a/src/main/java/com/debateseason_backend_v1/domain/terms/enums/TermsType.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/terms/enums/TermsType.java
@@ -1,0 +1,6 @@
+package com.debateseason_backend_v1.domain.terms.enums;
+
+public enum TermsType {
+	SERVICE,
+	PRIVACY
+}

--- a/src/main/java/com/debateseason_backend_v1/domain/terms/service/TermsServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/terms/service/TermsServiceV1.java
@@ -1,0 +1,30 @@
+package com.debateseason_backend_v1.domain.terms.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.debateseason_backend_v1.domain.repository.TermsRepository;
+import com.debateseason_backend_v1.domain.repository.entity.Terms;
+import com.debateseason_backend_v1.domain.terms.service.response.LatestTermsResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TermsServiceV1 {
+
+	private final TermsRepository termsRepository;
+
+	public List<LatestTermsResponse> getLatestTerms() {
+
+		List<Terms> latestTermsForAllTypes = termsRepository.findLatestTermsForAllTypes().orElse(List.of());
+
+		return latestTermsForAllTypes.stream()
+			.map(LatestTermsResponse::from)
+			.toList();
+	}
+
+}

--- a/src/main/java/com/debateseason_backend_v1/domain/terms/service/response/LatestTermsResponse.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/terms/service/response/LatestTermsResponse.java
@@ -2,19 +2,24 @@ package com.debateseason_backend_v1.domain.terms.service.response;
 
 import com.debateseason_backend_v1.domain.repository.entity.Terms;
 
+import lombok.Builder;
+
+@Builder
 public record LatestTermsResponse(
 	Long termsId,
 	String termsType,
+	String version,
 	String notionUrl
 ) {
 
 	public static LatestTermsResponse from(Terms terms) {
 
-		return new LatestTermsResponse(
-			terms.getId(),
-			terms.getTermsType().name(),
-			terms.getNotionUrl()
-		);
+		return LatestTermsResponse.builder()
+			.termsId(terms.getId())
+			.termsType(terms.getTermsType().name())
+			.version(terms.getVersion())
+			.notionUrl(terms.getNotionUrl())
+			.build();
 	}
 
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/terms/service/response/LatestTermsResponse.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/terms/service/response/LatestTermsResponse.java
@@ -1,0 +1,20 @@
+package com.debateseason_backend_v1.domain.terms.service.response;
+
+import com.debateseason_backend_v1.domain.repository.entity.Terms;
+
+public record LatestTermsResponse(
+	Long termsId,
+	String termsType,
+	String notionUrl
+) {
+
+	public static LatestTermsResponse from(Terms terms) {
+
+		return new LatestTermsResponse(
+			terms.getId(),
+			terms.getTermsType().name(),
+			terms.getNotionUrl()
+		);
+	}
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,6 @@ chat:
 
 social:
   kakao:
-    audience: "your-kakao-client-id"
+    audience: 18af8def9522316a9c30d75d997df2b1
   apple:
-    audience: "your-apple-client-id"
+    audience: com.rosyocean.debateseason


### PR DESCRIPTION
## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
최신 약관을 조회하는 API를 구현했습니다.

## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
## 1.최신 약관 목록 조회
```JAVA
public enum TermsType {
    SERVICE,
    PRIVACY
}

```
약관의 타입을 기준으로 최신 버전의 약관만 조회하는 기능입니다.

### JPQL 쿼리
```JAVA
@Query("SELECT t FROM Terms t " +
       "WHERE (t.termsType, t.version) IN " +
       "(SELECT t2.termsType, MAX(t2.version) FROM Terms t2 GROUP BY t2.termsType)"
)
Optional<List<Terms>> findLatestTermsForAllTypes();
```

### API 응답

<img width="825" alt="스크린샷 2025-03-16 오전 12 41 39" src="https://github.com/user-attachments/assets/3c581ad2-783b-4cb0-b231-630f7dce6654" />





## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->

