### PR TITLE
앱 버전 체크 API 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,169 @@
+# 토론철 백엔드 (DebateSeason Backend)
+
+## ✅ 목차
+
+[1. 프로젝트 소개](#-프로젝트-소개)  
+[2. 기술 스택](#-기술-스택)  
+[3. 아키텍처](#-아키텍처)  
+[4. 프로젝트 구조](#-프로젝트-구조)  
+[5. 주요 기능](#-주요-기능)   
+[6. 시작하기](#-시작하기)  
+[7. 환경 설정](#-환경-설정)  
+[8. API 문서](#-api-문서)  
+[9. CI/CD](#-CI/CD)  
+[10. 팀원 소개](#-팀원-소개)
+
+## 📋 프로젝트 소개
+
+토론철(DebateSeason)은 다양한 커뮤니티의 사용자들이 모여 여러 주제에 대해 실시간 채팅을 통해 토론을 할 수 있는 플랫폼입니다. 토론철은 “결국 대화를 통해 서로를 이해하고, 갈등을 해결할 수 있다”는
+신념으로 서비스를 만들고 있습니다.
+
+## 🛠 기술 스택
+
+<img src="https://img.shields.io/badge/Language-%23121011?style=for-the-badge"><img src="https://img.shields.io/badge/java-%23ED8B00?style=for-the-badge&logo=openjdk&logoColor=white"><img src="https://img.shields.io/badge/17-515151?style=for-the-badge">
+</br>
+<img src="https://img.shields.io/badge/Framework-%23121011?style=for-the-badge"><img src="https://img.shields.io/badge/springboot-6DB33F?style=for-the-badge&logo=springboot&logoColor=white"><img src="https://img.shields.io/badge/3.3.5-515151?style=for-the-badge">
+</br>
+<img src="https://img.shields.io/badge/Database-%23121011?style=for-the-badge"><img src="https://img.shields.io/badge/MariaDB-003545?style=for-the-badge&logo=mariadb&logoColor=white"><img src="https://img.shields.io/badge/11.4.4-515151?style=for-the-badge">
+</br>
+<img src="https://img.shields.io/badge/ORM-%23121011?style=for-the-badge"><img src="https://img.shields.io/badge/Spring_Data_JPA-6DB33F?style=for-the-badge&logo=spring&logoColor=white"><img src="https://img.shields.io/badge/3.1.0-515151?style=for-the-badge">
+</br>
+<img src="https://img.shields.io/badge/Security-%23121011?style=for-the-badge"><img src="https://img.shields.io/badge/Spring_Security-6DB33F?style=for-the-badge&logo=spring-security&logoColor=white"><img src="https://img.shields.io/badge/6.1.0-515151?style=for-the-badge"><img src="https://img.shields.io/badge/JWT-000000?style=for-the-badge&logo=jsonwebtokens&logoColor=white"><img src="https://img.shields.io/badge/0.12.3-515151?style=for-the-badge">
+</br>
+<img src="https://img.shields.io/badge/Communication-%23121011?style=for-the-badge"><img src="https://img.shields.io/badge/WebSocket-010101?style=for-the-badge&logo=socket.io&logoColor=white"><img src="https://img.shields.io/badge/STOMP-000000?style=for-the-badge"><img src="https://img.shields.io/badge/2.3.3-515151?style=for-the-badge">
+</br>
+<img src="https://img.shields.io/badge/Documentation-%23121011?style=for-the-badge"><img src="https://img.shields.io/badge/Swagger-85EA2D?style=for-the-badge&logo=swagger&logoColor=black"><img src="https://img.shields.io/badge/2.2.0-515151?style=for-the-badge">
+</br>
+<img src="https://img.shields.io/badge/Auth-%23121011?style=for-the-badge"><img src="https://img.shields.io/badge/OIDC-2671E5?style=for-the-badge&logo=openid&logoColor=white"><img src="https://img.shields.io/badge/Kakao_&_Apple-515151?style=for-the-badge">
+</br>
+<img src="https://img.shields.io/badge/Build-%23121011?style=for-the-badge"><img src="https://img.shields.io/badge/Gradle-02303A?style=for-the-badge&logo=gradle&logoColor=white"><img src="https://img.shields.io/badge/8.4-515151?style=for-the-badge">
+</br>
+<img src="https://img.shields.io/badge/Container-%23121011?style=for-the-badge"><img src="https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white"><img src="https://img.shields.io/badge/24.0.5-515151?style=for-the-badge">
+
+## 🏗 아키텍처
+
+<img width="1196" alt="Image" src="https://github.com/user-attachments/assets/7d779d6c-6128-4232-bd5c-ed6a6cebb033" />
+
+## 📑 프로젝트 구조
+
+```plaintext
+src/main/java/com/debateseason_backend_v1/
+├── common/             # 공통 모듈 (예외 처리, 응답 객체 등)
+├── config/             # 애플리케이션 설정
+├── domain/             # 도메인별 로직
+│   ├── chat/           # 채팅 관련
+│   ├── chatroom/       # 토론방 관련
+│   ├── issue/          # 이슈 관련
+│   ├── profile/        # 사용자 프로필 관련
+│   └── user/           # 사용자 인증 관련
+├── security/           # 보안 관련 (JWT 등)
+└── DebateSeasonBackendV1Application.java
+```
+
+## 🚀 주요 기능
+
+### 인증 및 사용자 관리
+
+- OIDC 인증 로그인(Kakao, Apple)
+- JWT 기반 인증
+- 토큰 재발급
+- 사용자 프로필 관리
+
+### 이슈방 (토론 주제)
+
+- 이슈 목록 조회
+- 이슈 상세 조회
+- 이슈 즐겨찾기
+
+### 채팅방 (토론 안건)
+
+- 채팅방 생성
+- 채팅방 상세 조회
+- 찬성/반대 투표 기능
+
+### 실시간 채팅
+
+- WebSocket/STOMP 기반 실시간 메시지 전송
+- 채팅 메시지 페이지네이션 조회
+
+## 📌 시작하기
+
+### 필수 조건
+
+- JDK 17 이상
+- Gradle
+- MariaDB
+
+### 설치 및 실행
+
+1. 저장소 클론
+   ```bash
+   git clone https://github.com/your-repo/DebateSeason_Backend_V1.git
+   ```
+
+2. 환경 설정 파일 생성
+   ```bash
+   cd DebateSeason_Backend_V1/src/main/resources
+   cp application-local.yml application-secret.yml
+   ```
+
+3. `application-secret.yml` 파일을 열어 데이터베이스 정보를 입력하세요. (아래 환경 설정 참고)
+
+
+4. 프로젝트 디렉토리로 이동
+   ```bash
+   cd DebateSeason_Backend_V1
+   ```
+
+5. 애플리케이션 빌드
+   ```bash
+   ./gradlew build
+   ```
+
+4. 애플리케이션 실행
+   ```bash
+   ./gradlew bootRun
+   ```
+
+### 환경 설정
+
+- `application-local.yml`: 로컬 개발 환경
+- `application-dev.yml`: 개발 서버 환경
+- `application-prod.yml`: 프로덕션 환경
+- `application-test.yml`: 테스트 환경
+
+로컬 환경에서 실행하려면 `src/main/resources` 디렉토리에 `application-secret.yml` 파일을 생성하고 다음 설정을 추가해야 합니다.
+
+```yaml
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create
+
+  datasource:
+    driver-class-name: org.mariadb.jdbc.Driver
+    url: jdbc:mariadb://localhost:3306/YOUR_DATABASE?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    username: YOUR_USERNAME
+    password: YOUR_PASSWORD
+```
+
+`YOUR_DATABASE`, `YOUR_USERNAME`, `YOUR_PASSWORD` 부분을 실제 MariaDB 정보로 변경하세요.
+
+## 📃 API 문서
+
+애플리케이션 실행 후 다음 URL에서 Swagger UI를 통해 API 문서를 확인할 수 있습니다.
+
+```
+http://localhost:8080/swagger-ui/index.html#/
+```
+
+## ♾️ CI/CD
+
+GitHub Actions과 AWS를 통해 브랜치에 따라 자동 배포가 진행됩니다.
+
+- 개발 환경: develop 브랜치에 코드가 병합되면, 빌드&테스트 후 개발 서버에 자동 배포
+- 운영 환경: main 브랜치에 코드가 병합되면, 빌드&테스트 후 운영 서버에 자동 배포
+
+## 👥 팀원 소개
+
+팀원 정보는 추후 업데이트 예정입니다.

--- a/src/main/java/com/debateseason_backend_v1/app/controller/AppVersionControllerV1.java
+++ b/src/main/java/com/debateseason_backend_v1/app/controller/AppVersionControllerV1.java
@@ -1,0 +1,32 @@
+package com.debateseason_backend_v1.app.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.debateseason_backend_v1.app.controller.docs.AppVersionControllerV1Docs;
+import com.debateseason_backend_v1.app.service.AppVersionServiceV1;
+import com.debateseason_backend_v1.app.service.response.AppVersionCheckResponse;
+import com.debateseason_backend_v1.common.response.ApiResult;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/app")
+public class AppVersionControllerV1 implements AppVersionControllerV1Docs {
+
+	private final AppVersionServiceV1 appVersionServiceV1;
+
+	@GetMapping("/versions/check")
+	public ApiResult<AppVersionCheckResponse> checkUpdate(
+		@RequestParam("versionCode") Integer versionCode
+	) {
+
+		AppVersionCheckResponse response = appVersionServiceV1.updateCheck(versionCode);
+
+		return ApiResult.success("버전 체크에 성공했습니다.", response);
+	}
+
+}

--- a/src/main/java/com/debateseason_backend_v1/app/controller/docs/AppVersionControllerV1Docs.java
+++ b/src/main/java/com/debateseason_backend_v1/app/controller/docs/AppVersionControllerV1Docs.java
@@ -1,0 +1,24 @@
+package com.debateseason_backend_v1.app.controller.docs;
+
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.debateseason_backend_v1.app.service.response.AppVersionCheckResponse;
+import com.debateseason_backend_v1.common.response.ApiResult;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "App API", description = "앱 관련 API")
+public interface AppVersionControllerV1Docs {
+
+	@Parameter(
+		name = "versionCode",
+		description = "체크할 앱 버전 코드",
+		required = true,
+		example = "10"
+	)
+	public ApiResult<AppVersionCheckResponse> checkUpdate(
+		@RequestParam("versionCode")
+		Integer versionCode
+	);
+}

--- a/src/main/java/com/debateseason_backend_v1/app/repository/AppVersionRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/app/repository/AppVersionRepository.java
@@ -1,0 +1,17 @@
+package com.debateseason_backend_v1.app.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.debateseason_backend_v1.app.repository.entity.AppVersion;
+
+public interface AppVersionRepository extends JpaRepository<AppVersion, Long> {
+
+	// 파라미터 versionCode 보다 큰 버전들 조회
+	@Query("SELECT a FROM AppVersion a WHERE a.versionCode > :versionCode ORDER BY a.versionCode DESC")
+	List<AppVersion> findNewerVersions(@Param("versionCode") Integer versionCode);
+
+}

--- a/src/main/java/com/debateseason_backend_v1/app/repository/entity/AppVersion.java
+++ b/src/main/java/com/debateseason_backend_v1/app/repository/entity/AppVersion.java
@@ -1,0 +1,48 @@
+package com.debateseason_backend_v1.app.repository.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "app_version")
+@EntityListeners(AuditingEntityListener.class)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AppVersion {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "app_version_id")
+	private Long id;
+
+	@Column(name = "version_code", nullable = false, unique = true)
+	private Integer versionCode; // 1, 2, 5, 14 ...
+
+	@Column(nullable = false)
+	private String version; // 1.0.0, 1.1.0 ...
+
+	@Column(name = "force_update", nullable = false)
+	private Boolean forceUpdate;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/debateseason_backend_v1/app/service/AppVersionServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/app/service/AppVersionServiceV1.java
@@ -1,0 +1,30 @@
+package com.debateseason_backend_v1.app.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.debateseason_backend_v1.app.repository.AppVersionRepository;
+import com.debateseason_backend_v1.app.repository.entity.AppVersion;
+import com.debateseason_backend_v1.app.service.response.AppVersionCheckResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AppVersionServiceV1 {
+
+	private final AppVersionRepository appVersionRepository;
+
+	public AppVersionCheckResponse updateCheck(Integer versionCode) {
+		// 클라이언트보다 최신 버전들 조회
+		List<AppVersion> newerVersions = appVersionRepository.findNewerVersions(versionCode);
+
+		// 강제 업데이트가 필요한 버전이 하나라도 있는지 확인
+		boolean isForceUpdate = newerVersions.stream().anyMatch(AppVersion::getForceUpdate);
+
+		return AppVersionCheckResponse.of(isForceUpdate);
+	}
+}

--- a/src/main/java/com/debateseason_backend_v1/app/service/response/AppVersionCheckResponse.java
+++ b/src/main/java/com/debateseason_backend_v1/app/service/response/AppVersionCheckResponse.java
@@ -1,0 +1,14 @@
+package com.debateseason_backend_v1.app.service.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "앱 버전 체크 응답 DTO", description = "앱 버전 체크 응답")
+public record AppVersionCheckResponse(
+	@Schema(description = "강제 업데이트 필요 여부", example = "true")
+	boolean forceUpdate
+) {
+
+	public static AppVersionCheckResponse of(boolean forceUpdate) {
+		return new AppVersionCheckResponse(forceUpdate);
+	}
+}

--- a/src/main/java/com/debateseason_backend_v1/config/WebSecurityConfig.java
+++ b/src/main/java/com/debateseason_backend_v1/config/WebSecurityConfig.java
@@ -34,7 +34,8 @@ public class WebSecurityConfig {
 		"/api/v1/users/login",
 		"/api/v2/users/login",
 		"/api/v1/auth/reissue",
-		"/api/v1/terms"
+		"/api/v1/terms",
+		"/api/v1/app/**"
 	};
 
 	@Bean


### PR DESCRIPTION
## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
앱 버전 체크를 위한 API를 구현했습니다.

## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
1. 앱 버전 체크 API
app version 테이블에서 앱 업데이트 여부를 체크하는 API입니다.
<img width="291" alt="스크린샷 2025-03-19 오후 5 55 27" src="https://github.com/user-attachments/assets/0f9cca1c-6aa8-460d-ada3-7a6b252e22fc" />


- 앱 관리 기능을 도메인으로 보기에는 애매한 점이 있어, 사진과 같이 프로젝트 루트 경로로 따로 분리했습니다.
- app_version 테이블은 관리자가 관리합니다. 앱 버전이 업데이트되면 프론드엔드 개발자분들과 협의 후 app_version에 앱 버전 데이터를 등록해야 합니다.
- 노션 공용 문서의 앱버전 관리 가이드를 참고해 주세요.
  - https://www.notion.so/API-19b034a1724480a79c21f2489577bace?pvs=4


## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->

