### PR TITLE
feat: 제3자 정보동의 약관 추가 및 조회 필터링 추가

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/domain/repository/UserTermsAgreementRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/UserTermsAgreementRepository.java
@@ -15,6 +15,7 @@ import com.debateseason_backend_v1.domain.terms.dto.UserTermsAgreementDto;
 @Repository
 public interface UserTermsAgreementRepository extends JpaRepository<UserTermsAgreement, Long> {
 
+	// 사용자의 최신 약관 동의일 조회
 	@Query("""
 			SELECT new com.debateseason_backend_v1.domain.terms.dto.UserTermsAgreementDto(
 				t.termsType, MAX(uta.createdAt)

--- a/src/main/java/com/debateseason_backend_v1/domain/terms/controller/TermsControllerV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/terms/controller/TermsControllerV1.java
@@ -30,9 +30,9 @@ public class TermsControllerV1 implements TermsControllerV1Docs {
 	private final TermsServiceV1 termsService;
 
 	@GetMapping
-	public ApiResult<List<LatestTermsResponse>> getLatestTerms() {
+	public ApiResult<List<LatestTermsResponse>> getLatestTerms(@AuthenticationPrincipal CustomUserDetails userDetails) {
 
-		List<LatestTermsResponse> latestTerms = termsService.getLatestTerms();
+		List<LatestTermsResponse> latestTerms = termsService.getLatestTerms(userDetails.getUserId());
 
 		return ApiResult.success(
 			"최신 약관 목록 조회가 완료되었습니다.",
@@ -50,7 +50,7 @@ public class TermsControllerV1 implements TermsControllerV1Docs {
 
 		return VoidApiResult.success("약관 동의에 성공했습니다.");
 	}
-	
+
 	@GetMapping("/agree")
 	public ApiResult<List<UserTermsAgreementResponse>> getUserTermsInfo(
 		@AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/com/debateseason_backend_v1/domain/terms/controller/docs/TermsControllerV1Docs.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/terms/controller/docs/TermsControllerV1Docs.java
@@ -27,7 +27,7 @@ public interface TermsControllerV1Docs {
 		description = "최신 버전의 이용약관들을 조회합니다."
 	)
 	@ApiResponse(responseCode = "200", description = "이용약관 목록 조회 성공")
-	public ApiResult<List<LatestTermsResponse>> getLatestTerms();
+	public ApiResult<List<LatestTermsResponse>> getLatestTerms(CustomUserDetails userDetails);
 
 	@Operation(
 		summary = "이용약관 동의",

--- a/src/main/java/com/debateseason_backend_v1/domain/terms/enums/TermsType.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/terms/enums/TermsType.java
@@ -9,7 +9,8 @@ public enum TermsType {
 
 	// 필수 약관
 	SERVICE(true, "서비스 이용약관", 1),
-	PRIVACY(true, "개인정보 처리방침", 2);
+	PRIVACY(true, "개인정보 처리방침", 2),
+	THIRD_PARTY(true, "제3자 정보제공", 3);
 
 	private final boolean required;
 	private final String displayName;

--- a/src/main/java/com/debateseason_backend_v1/domain/terms/service/TermsServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/terms/service/TermsServiceV1.java
@@ -36,11 +36,14 @@ public class TermsServiceV1 {
 	private final TermsRepository termsRepository;
 	private final UserTermsAgreementRepository userTermsAgreementRepository;
 
-	public List<LatestTermsResponse> getLatestTerms() {
+	public List<LatestTermsResponse> getLatestTerms(Long userId) {
 
 		List<Terms> latestTermsForAllTypes = termsRepository.findAllLatestTerms();
 
+		Set<Long> agreedTermsIdsByUserId = userTermsAgreementRepository.findAgreedTermsIdsByUserId(userId);
+
 		return latestTermsForAllTypes.stream()
+			.filter(terms -> !agreedTermsIdsByUserId.contains(terms.getId()))
 			.map(LatestTermsResponse::from)
 			.sorted(Comparator.comparingInt(response -> response.termsType().getDisplayOrder()))
 			.toList();


### PR DESCRIPTION
## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
새로운 약관을 추가했고, 약관 조회 시 이미 동의한 약관은 필터링 되도록 기능을 추가했습니다.

## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
## 1. 새로운 약관 추가

```JAVA
public enum TermsType {

	// 필수 약관
	SERVICE(true, "서비스 이용약관", 1),
	PRIVACY(true, "개인정보 처리방침", 2),
	THIRD_PARTY(true, "제3자 정보제공", 3); // 추가

	...

}
```
## 2. 이미 동의한 약관은 필터링

```JAVA
List<Terms> latestTermsForAllTypes = termsRepository.findAllLatestTerms(); // 최신 약관 목록

Set<Long> agreedTermsIdsByUserId = userTermsAgreementRepository.findAgreedTermsIdsByUserId(userId); // 사용자가 동의한 약관 ID 셋

return latestTermsForAllTypes.stream()
    .filter(terms -> !agreedTermsIdsByUserId.contains(terms.getId())) // 필터링
    .map(LatestTermsResponse::from)
    .sorted(Comparator.comparingInt(response -> response.termsType().getDisplayOrder()))
    .toList();
```


## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->

