### PR TITLE
Hotfix: 토큰 재발급 동시성 문제 해결(운영 서버)

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/common/exception/ErrorCode.java
+++ b/src/main/java/com/debateseason_backend_v1/common/exception/ErrorCode.java
@@ -72,6 +72,10 @@ public enum ErrorCode implements CodeInterface {
 	ALREADY_REPORTED(6001, HttpStatus.CONFLICT, "이미 신고된 메시지 입니다."),
 	REPORT_ALREADY_PROCESSED(6002, HttpStatus.CONFLICT, "이미 처리된 신고는 상태를 변경할 수 없습니다."),
 	SELF_REPORT_NOT_ALLOWED(6003, HttpStatus.BAD_REQUEST, "자신의 메시지는 신고할 수 없습니다."),
+
+	// 7000번대: 동시성 관련 에러
+	CONCURRENT_REQUEST(7000, HttpStatus.CONFLICT, "요청 처리 중 충돌이 발생했습니다. 잠시 후 다시 시도해주세요."),
+
 	NOT_FOUND_REPORT(404, HttpStatus.NOT_FOUND, "NOT_FOUND"),
 
 	// API 요청 에러
@@ -82,14 +86,14 @@ public enum ErrorCode implements CodeInterface {
 
 	// 400번대
 	NOT_FOUND_ISSUE(404, HttpStatus.NOT_FOUND, "주어진 id값에 해당하는 이슈방을 찾을 수 없습니다."),
-	NOT_FOUND_CHATROOM(404,HttpStatus.NOT_FOUND,"주어진 chatroomId로 해당하는 채팅방을 찾을 수 없습니다."),
+	NOT_FOUND_CHATROOM(404, HttpStatus.NOT_FOUND, "주어진 chatroomId로 해당하는 채팅방을 찾을 수 없습니다."),
 	NOT_FOUND_ISSUE_WITH_CATEGORY(400, HttpStatus.NOT_FOUND, "해당 category의 이슈방을 찾을 수 없습니다."),
 
 	// 페이지네이션 오류
-	PAGE_OUT_OF_RANGE(404,HttpStatus.NOT_FOUND,"검색범위를 넘어섰습니다. 내용을 불러올 수 없습니다."),
+	PAGE_OUT_OF_RANGE(404, HttpStatus.NOT_FOUND, "검색범위를 넘어섰습니다. 내용을 불러올 수 없습니다."),
 
 	// Media 관련 오류
-	MEDIA_NOT_FOUND(404,HttpStatus.NOT_FOUND,"요청하신 미디어는 존재하지 않습니다.");
+	MEDIA_NOT_FOUND(404, HttpStatus.NOT_FOUND, "요청하신 미디어는 존재하지 않습니다.");
 
 	private final Integer code;
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/debateseason_backend_v1/domain/auth/service/AuthServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/auth/service/AuthServiceV1.java
@@ -45,7 +45,7 @@ public class AuthServiceV1 {
 
 		} catch (ObjectOptimisticLockingFailureException e) {
 			log.warn("Refresh Token 재발급 중 동시성 충돌 발생: {}", request.refreshToken());
-			throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN, "요청 처리 중 충돌이 발생했습니다. 다시 시도해주세요.");
+			throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
 		}
 
 	}

--- a/src/main/java/com/debateseason_backend_v1/domain/auth/service/AuthServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/auth/service/AuthServiceV1.java
@@ -1,5 +1,6 @@
 package com.debateseason_backend_v1.domain.auth.service;
 
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -14,7 +15,9 @@ import com.debateseason_backend_v1.domain.repository.entity.RefreshToken;
 import com.debateseason_backend_v1.security.jwt.JwtUtil;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -25,25 +28,26 @@ public class AuthServiceV1 {
 
 	@Transactional
 	public TokenReissueResponse reissueToken(TokenReissueServiceRequest request) {
+		try {
 
-		RefreshToken refreshToken = refreshTokenRepository.findByToken(request.refreshToken())
-			.orElseThrow(() -> new CustomException(ErrorCode.INVALID_REFRESH_TOKEN));
+			RefreshToken refreshToken = refreshTokenRepository.findByToken(request.refreshToken())
+				.orElseThrow(() -> new CustomException(ErrorCode.INVALID_REFRESH_TOKEN));
 
-		String newAccessToken = jwtUtil.createAccessToken(refreshToken.getUser().getId());
-		String newRefreshToken = jwtUtil.createRefreshToken(refreshToken.getUser().getId());
+			String newAccessToken = jwtUtil.createAccessToken(refreshToken.getUser().getId());
+			String newRefreshToken = jwtUtil.createRefreshToken(refreshToken.getUser().getId());
 
-		refreshTokenRepository.delete(refreshToken);
+			refreshToken.updateToken(newAccessToken);
 
-		RefreshToken token = RefreshToken.builder()
-			.token(newRefreshToken)
-			.user(refreshToken.getUser())
-			.build();
-		refreshTokenRepository.save(token);
+			return TokenReissueResponse.builder()
+				.accessToken(newAccessToken)
+				.refreshToken(newRefreshToken)
+				.build();
 
-		return TokenReissueResponse.builder()
-			.accessToken(newAccessToken)
-			.refreshToken(newRefreshToken)
-			.build();
+		} catch (ObjectOptimisticLockingFailureException e) {
+			log.warn("Refresh Token 재발급 중 동시성 충돌 발생: {}", request.refreshToken());
+			throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN, "요청 처리 중 충돌이 발생했습니다. 다시 시도해주세요.");
+		}
+
 	}
 
 	public Long getCurrentUserId() {

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/RefreshTokenRepository.java
@@ -3,14 +3,20 @@ package com.debateseason_backend_v1.domain.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.debateseason_backend_v1.domain.repository.entity.RefreshToken;
 
+import jakarta.persistence.LockModeType;
+
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
-	Optional<RefreshToken> findByToken(String token);
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT rt FROM RefreshToken rt WHERE rt.token = :token")
+	Optional<RefreshToken> findByToken(@Param("token") String token);
 
 	void deleteByToken(String token);
 

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/RefreshToken.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/RefreshToken.java
@@ -3,6 +3,7 @@ package com.debateseason_backend_v1.domain.repository.entity;
 import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;
@@ -15,6 +16,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,6 +34,9 @@ public class RefreshToken {
 	@Column(name = "refresh_token_id")
 	private Long id;
 
+	@Version
+	private Long version;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
@@ -39,19 +44,23 @@ public class RefreshToken {
 	@Column(name = "token")
 	private String token;
 
-	@Column(name = "expiration_at")
-	private LocalDateTime expirationAt;
-
 	@CreatedDate
 	@Column(name = "created_at", updatable = false)
 	private LocalDateTime createdAt;
 
+	@LastModifiedDate
+	@Column(name = "update_at")
+	private LocalDateTime updatedAt;
+
 	@Builder
-	protected RefreshToken(User user, String token, LocalDateTime expirationAt) {
+	protected RefreshToken(User user, String token) {
 
 		this.user = user;
 		this.token = token;
-		this.expirationAt = expirationAt;
+	}
+
+	public void updateToken(String token) {
+		this.token = token;
 	}
 
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/user/service/UserServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/service/UserServiceV1.java
@@ -1,7 +1,5 @@
 package com.debateseason_backend_v1.domain.user.service;
 
-import java.time.LocalDateTime;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,7 +48,12 @@ public class UserServiceV1 {
 		String newAccessToken = jwtUtil.createAccessToken(user.getId());
 		String newRefreshToken = jwtUtil.createRefreshToken(user.getId());
 
-		saveRefreshToken(user, newRefreshToken, jwtUtil.getRefreshTokenExpireTime());
+		RefreshToken refreshToken = RefreshToken.builder()
+			.token(newRefreshToken)
+			.user(user)
+			.build();
+
+		refreshTokenRepository.save(refreshToken);
 
 		boolean profileStatus = profileRepository.existsByUserId(user.getId());
 
@@ -102,19 +105,6 @@ public class UserServiceV1 {
 			.build();
 
 		return userRepository.save(user);
-	}
-
-	private void saveRefreshToken(User user, String refresh, Long expiredMs) {
-
-		LocalDateTime expiration = LocalDateTime.now().plusSeconds(expiredMs / 1000);
-
-		RefreshToken refreshToken = RefreshToken.builder()
-			.token(refresh)
-			.user(user)
-			.expirationAt(expiration)
-			.build();
-
-		refreshTokenRepository.save(refreshToken);
 	}
 
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/user/service/UserServiceV2.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/service/UserServiceV2.java
@@ -48,7 +48,12 @@ public class UserServiceV2 {
 		String newAccessToken = jwtUtil.createAccessToken(user.getId());
 		String newRefreshToken = jwtUtil.createRefreshToken(user.getId());
 
-		saveRefreshToken(user, newRefreshToken, jwtUtil.getRefreshTokenExpireTime());
+		RefreshToken refreshToken = RefreshToken.builder()
+			.token(newRefreshToken)
+			.user(user)
+			.build();
+
+		refreshTokenRepository.save(refreshToken);
 
 		boolean profileStatus = profileRepository.existsByUserId(user.getId());
 
@@ -80,7 +85,6 @@ public class UserServiceV2 {
 		RefreshToken refreshToken = RefreshToken.builder()
 			.token(refresh)
 			.user(user)
-			.expirationAt(expiration)
 			.build();
 
 		refreshTokenRepository.save(refreshToken);

--- a/src/main/java/com/debateseason_backend_v1/security/jwt/JwtUtil.java
+++ b/src/main/java/com/debateseason_backend_v1/security/jwt/JwtUtil.java
@@ -110,8 +110,4 @@ public class JwtUtil {
 			.getPayload();
 	}
 
-	public long getRefreshTokenExpireTime() {
-		return refreshTokenExpireTime;
-	}
-
 }

--- a/src/test/java/com/debateseason_backend_v1/domain/auth/service/TokenReissueConcurrencyTest.java
+++ b/src/test/java/com/debateseason_backend_v1/domain/auth/service/TokenReissueConcurrencyTest.java
@@ -1,0 +1,84 @@
+package com.debateseason_backend_v1.domain.auth.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.debateseason_backend_v1.domain.auth.service.request.TokenReissueServiceRequest;
+import com.debateseason_backend_v1.domain.repository.RefreshTokenRepository;
+import com.debateseason_backend_v1.domain.repository.UserRepository;
+import com.debateseason_backend_v1.domain.repository.entity.RefreshToken;
+import com.debateseason_backend_v1.domain.repository.entity.User;
+import com.debateseason_backend_v1.domain.user.enums.SocialType;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class TokenReissueConcurrencyTest {
+
+	@Autowired
+	private AuthServiceV1 authService;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private RefreshTokenRepository refreshTokenRepository;
+
+	@Test
+	@DisplayName("동일한 리프레시 토큰으로 동시에 재발급 요청 시, 한 번만 성공해야 한다")
+	void reissueToken_concurrency_test() throws InterruptedException {
+		// given
+		User testUser = userRepository.save(User.builder()
+			.socialType(SocialType.KAKAO)
+			.externalId("concurrency_test_user")
+			.build());
+
+		String initialRefreshToken = "initial-refresh-token-for-concurrency-test";
+		refreshTokenRepository.save(RefreshToken.builder()
+			.user(testUser)
+			.token(initialRefreshToken)
+			.build());
+
+		int threadCount = 10;
+		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch latch = new CountDownLatch(threadCount);
+
+		AtomicInteger successCount = new AtomicInteger(0);
+		AtomicInteger failureCount = new AtomicInteger(0);
+
+		TokenReissueServiceRequest request = TokenReissueServiceRequest.builder()
+			.refreshToken(initialRefreshToken)
+			.build();
+
+		// when
+		for (int i = 0; i < threadCount; i++) {
+			executorService.submit(() -> {
+				try {
+					// 각 스레드에서 authService를 직접 호출
+					authService.reissueToken(request);
+					successCount.incrementAndGet();
+				} catch (Exception e) {
+					failureCount.incrementAndGet();
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+		executorService.shutdown();
+
+		// then
+		assertThat(successCount.get()).isEqualTo(1);
+		assertThat(failureCount.get()).isEqualTo(threadCount - 1);
+	}
+}


### PR DESCRIPTION
## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
토큰 재발급시 동시성 이슈가 생겨 문제를 해결함.

## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
1. 낙관적락을 이용해 토큰 재발급시 발생한 동시성 문제를 해결함.
```java
public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {

	@Lock(LockModeType.PESSIMISTIC_WRITE) // 낙관적락
	@Query("SELECT rt FROM RefreshToken rt WHERE rt.token = :token")
	Optional<RefreshToken> findByToken(@Param("token") String token);

}

```

```java
@Entity
@Getter
@Table(name = "refresh_tokens")
@EntityListeners(AuditingEntityListener.class)
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class RefreshToken {

       ...

        // 동시성을 관리할 버전
	@Version
	private Long version; 

	...

}
```

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->


