### PR TITLE
프로필 추가 정보(프로필 색상, 거주지) 입력 추가

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/common/exception/ErrorCode.java
+++ b/src/main/java/com/debateseason_backend_v1/common/exception/ErrorCode.java
@@ -42,6 +42,8 @@ public enum ErrorCode implements CodeInterface {
 	MISSING_REQUIRED_COMMUNITY(2012, HttpStatus.BAD_REQUEST, "커뮤니티 선택은 필수입니다."),
 	MISSING_REQUIRED_GENDER_TYPE(2013, HttpStatus.BAD_REQUEST, "성별은 선택은 필수입니다."),
 	MISSING_REQUIRED_AGE_RANGE(2014, HttpStatus.BAD_REQUEST, "연령대는 선택은 필수입니다."),
+	NOT_SUPPORTED_PROVINCE(2015, HttpStatus.BAD_REQUEST, "지원하지 않는 시도입니다."),
+	NOT_SUPPORTED_DISTRICT(2016, HttpStatus.BAD_REQUEST, "지원하지 않는 시군구입니다."),
 
 	// 3000번대 User(인증) 관련 에러
 	NOT_FOUND_USER(3000, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/debateseason_backend_v1/common/exception/ErrorCode.java
+++ b/src/main/java/com/debateseason_backend_v1/common/exception/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode implements CodeInterface {
 	MISSING_REQUIRED_AGE_RANGE(2014, HttpStatus.BAD_REQUEST, "연령대는 선택은 필수입니다."),
 	NOT_SUPPORTED_PROVINCE(2015, HttpStatus.BAD_REQUEST, "지원하지 않는 시도입니다."),
 	NOT_SUPPORTED_DISTRICT(2016, HttpStatus.BAD_REQUEST, "지원하지 않는 시군구입니다."),
+	INVALID_DISTRICT_PROVINCE_RELATION(2017, HttpStatus.BAD_REQUEST, "선택한 시군구가 해당 시도에 속하지 않습니다."),
 
 	// 3000번대 User(인증) 관련 에러
 	NOT_FOUND_USER(3000, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/debateseason_backend_v1/domain/profile/controller/request/ProfileRegisterRequest.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/profile/controller/request/ProfileRegisterRequest.java
@@ -1,7 +1,9 @@
 package com.debateseason_backend_v1.domain.profile.controller.request;
 
 import com.debateseason_backend_v1.domain.profile.enums.AgeRangeType;
+import com.debateseason_backend_v1.domain.profile.enums.DistrictType;
 import com.debateseason_backend_v1.domain.profile.enums.GenderType;
+import com.debateseason_backend_v1.domain.profile.enums.ProvinceType;
 import com.debateseason_backend_v1.domain.profile.service.request.ProfileRegisterServiceRequest;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,8 +12,8 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(title = "프로필 등록 요청 DTO", description = "프로필 등록 요청")
 public record ProfileRegisterRequest(
-	@Schema(description = "프로필 컬러", example = "RED")
-	String profileColor,
+	@Schema(description = "프로필 이미지", example = "RED")
+	String profileImage,
 
 	@Schema(description = "사용자 닉네임", example = "토론왕")
 	@NotBlank(message = "닉네임은 필수입니다.")
@@ -27,18 +29,34 @@ public record ProfileRegisterRequest(
 
 	@Schema(description = "연령대", example = "20대")
 	@NotNull(message = "연령대 선택은 필수입니다.")
-	AgeRangeType ageRange
+	AgeRangeType ageRange,
+
+	@Schema(description = "거주 시도 코드", example = "11")
+	ProvinceType residenceProvince,
+
+	@Schema(description = "거주 시·군·구 코드", example = "11030")
+	DistrictType residenceDistrict,
+
+	@Schema(description = "출신 시도 코드", example = "21")
+	ProvinceType hometownProvince,
+
+	@Schema(description = "출신 시·군·구 코드", example = "21010")
+	DistrictType hometownDistrict
 ) {
 
 	public ProfileRegisterServiceRequest toServiceRequest(Long userId) {
 
 		return ProfileRegisterServiceRequest.builder()
 			.userId(userId)
-			.profileColor(profileColor)
+			.profileImage(profileImage)
 			.nickname(nickname)
 			.communityId(communityId)
 			.gender(gender)
 			.ageRange(ageRange)
+			.residenceProvince(residenceProvince)
+			.residenceDistrict(residenceDistrict)
+			.hometownProvince(hometownProvince)
+			.hometownDistrict(hometownDistrict)
 			.build();
 	}
 

--- a/src/main/java/com/debateseason_backend_v1/domain/profile/controller/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/profile/controller/request/ProfileUpdateRequest.java
@@ -1,7 +1,9 @@
 package com.debateseason_backend_v1.domain.profile.controller.request;
 
 import com.debateseason_backend_v1.domain.profile.enums.AgeRangeType;
+import com.debateseason_backend_v1.domain.profile.enums.DistrictType;
 import com.debateseason_backend_v1.domain.profile.enums.GenderType;
+import com.debateseason_backend_v1.domain.profile.enums.ProvinceType;
 import com.debateseason_backend_v1.domain.profile.service.request.ProfileUpdateServiceRequest;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,8 +12,8 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(title = "프로필 수정 요청 DTO", description = "프로필 수정 요청")
 public record ProfileUpdateRequest(
-	@Schema(description = "사용자 색상", example = "RED")
-	String profileColor,
+	@Schema(description = "프로필 이미지", example = "RED")
+	String profileImage,
 
 	@Schema(description = "사용자 닉네임", example = "토론왕")
 	@NotBlank(message = "닉네임은 필수입니다.")
@@ -27,18 +29,34 @@ public record ProfileUpdateRequest(
 
 	@Schema(description = "연령대", example = "20대")
 	@NotNull(message = "연령대 선택은 필수입니다.")
-	AgeRangeType ageRange
+	AgeRangeType ageRange,
+
+	@Schema(description = "거주 시도 코드", example = "11")
+	ProvinceType residenceProvince,
+
+	@Schema(description = "거주 시·군·구 코드", example = "11030")
+	DistrictType residenceDistrict,
+
+	@Schema(description = "출신 시도 코드", example = "21")
+	ProvinceType hometownProvince,
+
+	@Schema(description = "출신 시·군·구 코드", example = "21010")
+	DistrictType hometownDistrict
 ) {
 
 	public ProfileUpdateServiceRequest toServiceRequest(Long userId) {
 
 		return ProfileUpdateServiceRequest.builder()
 			.userId(userId)
-			.profileColor(profileColor)
+			.profileImage(profileImage)
 			.nickname(nickname)
 			.communityId(communityId)
 			.gender(gender)
 			.ageRange(ageRange)
+			.residenceProvince(residenceProvince)
+			.residenceDistrict(residenceDistrict)
+			.hometownProvince(hometownProvince)
+			.hometownDistrict(hometownDistrict)
 			.build();
 	}
 

--- a/src/main/java/com/debateseason_backend_v1/domain/profile/domain/Region.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/profile/domain/Region.java
@@ -1,0 +1,44 @@
+package com.debateseason_backend_v1.domain.profile.domain;
+
+import com.debateseason_backend_v1.common.exception.CustomException;
+import com.debateseason_backend_v1.common.exception.ErrorCode;
+import com.debateseason_backend_v1.domain.profile.enums.DistrictType;
+import com.debateseason_backend_v1.domain.profile.enums.ProvinceType;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Embeddable
+@EqualsAndHashCode
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Region {
+
+	@Enumerated(EnumType.STRING)
+	private ProvinceType provinceType;
+
+	@Enumerated(EnumType.STRING)
+	private DistrictType districtType;
+
+	public static Region of(ProvinceType provinceType, DistrictType districtType) {
+
+		if (districtType.getProvinceType() != provinceType) {
+			throw new CustomException(ErrorCode.INVALID_DISTRICT_PROVINCE_RELATION);
+		}
+
+		return Region.builder()
+			.provinceType(provinceType)
+			.districtType(districtType)
+			.build();
+	}
+
+}

--- a/src/main/java/com/debateseason_backend_v1/domain/profile/enums/DistrictType.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/profile/enums/DistrictType.java
@@ -1,0 +1,349 @@
+package com.debateseason_backend_v1.domain.profile.enums;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.debateseason_backend_v1.common.exception.CustomException;
+import com.debateseason_backend_v1.common.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DistrictType {
+
+	// 서울특별시
+	JONGNO("11010", "종로구", ProvinceType.SEOUL),
+	JUNG_SEOUL("11020", "중구", ProvinceType.SEOUL),
+	YONGSAN("11030", "용산구", ProvinceType.SEOUL),
+	SEONGDONG("11040", "성동구", ProvinceType.SEOUL),
+	GWANGJIN("11050", "광진구", ProvinceType.SEOUL),
+	DONGDAEMUN("11060", "동대문구", ProvinceType.SEOUL),
+	JUNGNANG("11070", "중랑구", ProvinceType.SEOUL),
+	SEONGBUK("11080", "성북구", ProvinceType.SEOUL),
+	GANGBUK("11090", "강북구", ProvinceType.SEOUL),
+	DOBONG("11100", "도봉구", ProvinceType.SEOUL),
+	NOWON("11110", "노원구", ProvinceType.SEOUL),
+	EUNPYEONG("11120", "은평구", ProvinceType.SEOUL),
+	SEODAEMUN("11130", "서대문구", ProvinceType.SEOUL),
+	MAPO("11140", "마포구", ProvinceType.SEOUL),
+	YANGCHEON("11150", "양천구", ProvinceType.SEOUL),
+	GANGSEO_SEOUL("11160", "강서구", ProvinceType.SEOUL),
+	GURO("11170", "구로구", ProvinceType.SEOUL),
+	GEUMCHEON("11180", "금천구", ProvinceType.SEOUL),
+	YEONGDEUNGPO("11190", "영등포구", ProvinceType.SEOUL),
+	DONGJAK("11200", "동작구", ProvinceType.SEOUL),
+	GWANAK("11210", "관악구", ProvinceType.SEOUL),
+	SEOCHO("11220", "서초구", ProvinceType.SEOUL),
+	GANGNAM("11230", "강남구", ProvinceType.SEOUL),
+	SONGPA("11240", "송파구", ProvinceType.SEOUL),
+	GANGDONG("11250", "강동구", ProvinceType.SEOUL),
+
+	// 부산광역시
+	JUNG_BUSAN("21010", "중구", ProvinceType.BUSAN),
+	SEO_BUSAN("21020", "서구", ProvinceType.BUSAN),
+	DONG_BUSAN("21030", "동구", ProvinceType.BUSAN),
+	YEONGDO("21040", "영도구", ProvinceType.BUSAN),
+	BUSANJIN("21050", "부산진구", ProvinceType.BUSAN),
+	DONGNAE("21060", "동래구", ProvinceType.BUSAN),
+	NAM_BUSAN("21070", "남구", ProvinceType.BUSAN),
+	BUK_BUSAN("21080", "북구", ProvinceType.BUSAN),
+	HAEUNDAE("21090", "해운대구", ProvinceType.BUSAN),
+	SAHA("21100", "사하구", ProvinceType.BUSAN),
+	GEUMJEONG("21110", "금정구", ProvinceType.BUSAN),
+	GANGSEO_BUSAN("21120", "강서구", ProvinceType.BUSAN),
+	YEONJE("21130", "연제구", ProvinceType.BUSAN),
+	SUYEONG("21140", "수영구", ProvinceType.BUSAN),
+	SASANG("21150", "사상구", ProvinceType.BUSAN),
+	GIJANG("21310", "기장군", ProvinceType.BUSAN),
+
+	// 대구광역시
+	JUNG_DAEGU("22010", "중구", ProvinceType.DAEGU),
+	DONG_DAEGU("22020", "동구", ProvinceType.DAEGU),
+	SEO_DAEGU("22030", "서구", ProvinceType.DAEGU),
+	NAM_DAEGU("22040", "남구", ProvinceType.DAEGU),
+	BUK_DAEGU("22050", "북구", ProvinceType.DAEGU),
+	SUSEONG("22060", "수성구", ProvinceType.DAEGU),
+	DALSEO("22070", "달서구", ProvinceType.DAEGU),
+	DALSEONG("22310", "달성군", ProvinceType.DAEGU),
+	GUNWI("22330", "군위군", ProvinceType.DAEGU),
+
+	// 인천광역시
+	JUNG_INCHEON("23010", "중구", ProvinceType.INCHEON),
+	DONG_INCHEON("23020", "동구", ProvinceType.INCHEON),
+	MICHUHOL("23040", "미추홀구", ProvinceType.INCHEON),
+	YEONSU("23050", "연수구", ProvinceType.INCHEON),
+	NAMDONG("23060", "남동구", ProvinceType.INCHEON),
+	BUPYEONG("23070", "부평구", ProvinceType.INCHEON),
+	GYEYANG("23080", "계양구", ProvinceType.INCHEON),
+	SEO_INCHEON("23090", "서구", ProvinceType.INCHEON),
+	GANGHWA("23310", "강화군", ProvinceType.INCHEON),
+	ONGJIN("23320", "옹진군", ProvinceType.INCHEON),
+
+	// 광주광역시
+	DONG_GWANGJU("24010", "동구", ProvinceType.GWANGJU),
+	SEO_GWANGJU("24020", "서구", ProvinceType.GWANGJU),
+	NAM_GWANGJU("24030", "남구", ProvinceType.GWANGJU),
+	BUK_GWANGJU("24040", "북구", ProvinceType.GWANGJU),
+	GWANGSAN("24050", "광산구", ProvinceType.GWANGJU),
+
+	// 대전광역시
+	DONG_DAEJEON("25010", "동구", ProvinceType.DAEJEON),
+	JUNG_DAEJEON("25020", "중구", ProvinceType.DAEJEON),
+	SEO_DAEJEON("25030", "서구", ProvinceType.DAEJEON),
+	YUSEONG("25040", "유성구", ProvinceType.DAEJEON),
+	DAEDEOK("25050", "대덕구", ProvinceType.DAEJEON),
+
+	// 울산광역시
+	JUNG_ULSAN("26010", "중구", ProvinceType.ULSAN),
+	NAM_ULSAN("26020", "남구", ProvinceType.ULSAN),
+	DONG_ULSAN("26030", "동구", ProvinceType.ULSAN),
+	BUK_ULSAN("26040", "북구", ProvinceType.ULSAN),
+	ULJU("26310", "울주군", ProvinceType.ULSAN),
+
+	// 세종특별자치시
+	SEJONG_JOCHIWON("29011", "조치원읍", ProvinceType.SEJONG),
+	SEJONG_YEONGI("29021", "연기면", ProvinceType.SEJONG),
+	SEJONG_YEONDONG("29022", "연동면", ProvinceType.SEJONG),
+	SEJONG_BUGANG("29023", "부강면", ProvinceType.SEJONG),
+	SEJONG_GEUMNAM("29024", "금남면", ProvinceType.SEJONG),
+	SEJONG_JANGUN("29025", "장군면", ProvinceType.SEJONG),
+	SEJONG_YEONSEO("29026", "연서면", ProvinceType.SEJONG),
+	SEJONG_JEONUI("29027", "전의면", ProvinceType.SEJONG),
+	SEJONG_JEONDONG("29028", "전동면", ProvinceType.SEJONG),
+	SEJONG_SOJEONG("29029", "소정면", ProvinceType.SEJONG),
+	SEJONG_HANSOL("29031", "한솔동", ProvinceType.SEJONG),
+	SEJONG_SAEROM("29032", "새롬동", ProvinceType.SEJONG),
+	SEJONG_NASEONG("29033", "나성동", ProvinceType.SEJONG),
+	SEJONG_DAJEONG("29034", "다정동", ProvinceType.SEJONG),
+	SEJONG_DODAM("29035", "도담동", ProvinceType.SEJONG),
+	SEJONG_EOJIN("29036", "어진동", ProvinceType.SEJONG),
+	SEJONG_HAEMIL("29037", "해밀동", ProvinceType.SEJONG),
+	SEJONG_AREUM("29038", "아름동", ProvinceType.SEJONG),
+	SEJONG_JONGCHON("29039", "종촌동", ProvinceType.SEJONG),
+	SEJONG_GOUN("29040", "고운동", ProvinceType.SEJONG),
+	SEJONG_BORAM("29041", "보람동", ProvinceType.SEJONG),
+	SEJONG_DAEPYEONG("29042", "대평동", ProvinceType.SEJONG),
+	SEJONG_SODAM("29043", "소담동", ProvinceType.SEJONG),
+	SEJONG_BANGOK("29044", "반곡동", ProvinceType.SEJONG),
+
+	// 경기도
+	SUWON_JANGAN("31010", "수원시 장안구", ProvinceType.GYEONGGI),
+	SUWON_GWONSEON("31020", "수원시 권선구", ProvinceType.GYEONGGI),
+	SUWON_PALDAL("31030", "수원시 팔달구", ProvinceType.GYEONGGI),
+	SUWON_YEONGTONG("31040", "수원시 영통구", ProvinceType.GYEONGGI),
+	SEONGNAM_SUJEONG("31050", "성남시 수정구", ProvinceType.GYEONGGI),
+	SEONGNAM_JUNGWON("31060", "성남시 중원구", ProvinceType.GYEONGGI),
+	SEONGNAM_BUNDANG("31070", "성남시 분당구", ProvinceType.GYEONGGI),
+	UIJEONGBU("31080", "의정부시", ProvinceType.GYEONGGI),
+	ANYANG_MANAN("31090", "안양시 만안구", ProvinceType.GYEONGGI),
+	ANYANG_DONGAN("31100", "안양시 동안구", ProvinceType.GYEONGGI),
+	BUCHEON("31110", "부천시", ProvinceType.GYEONGGI),
+	GWANGMYEONG("31120", "광명시", ProvinceType.GYEONGGI),
+	PYEONGTAEK("31130", "평택시", ProvinceType.GYEONGGI),
+	DONGDUCHEON("31140", "동두천시", ProvinceType.GYEONGGI),
+	ANSAN_SANGROK("31150", "안산시 상록구", ProvinceType.GYEONGGI),
+	ANSAN_DANWON("31160", "안산시 단원구", ProvinceType.GYEONGGI),
+	GOYANG_DEOGYANG("31170", "고양시 덕양구", ProvinceType.GYEONGGI),
+	GOYANG_ILSANDONG("31180", "고양시 일산동구", ProvinceType.GYEONGGI),
+	GOYANG_ILSANSEO("31190", "고양시 일산서구", ProvinceType.GYEONGGI),
+	GWACHEON("31200", "과천시", ProvinceType.GYEONGGI),
+	GURI("31210", "구리시", ProvinceType.GYEONGGI),
+	NAMYANGJU("31220", "남양주시", ProvinceType.GYEONGGI),
+	OSAN("31230", "오산시", ProvinceType.GYEONGGI),
+	SIHEUNG("31240", "시흥시", ProvinceType.GYEONGGI),
+	GUNPO("31250", "군포시", ProvinceType.GYEONGGI),
+	UIWANG("31260", "의왕시", ProvinceType.GYEONGGI),
+	HANAM("31270", "하남시", ProvinceType.GYEONGGI),
+	YONGIN_CHEOIN("31280", "용인시 처인구", ProvinceType.GYEONGGI),
+	YONGIN_GIHEUNG("31290", "용인시 기흥구", ProvinceType.GYEONGGI),
+	YONGIN_SUJI("31300", "용인시 수지구", ProvinceType.GYEONGGI),
+	PAJU("31310", "파주시", ProvinceType.GYEONGGI),
+	ICHEON("31320", "이천시", ProvinceType.GYEONGGI),
+	ANSEONG("31330", "안성시", ProvinceType.GYEONGGI),
+	GIMPO("31340", "김포시", ProvinceType.GYEONGGI),
+	HWASEONG("31350", "화성시", ProvinceType.GYEONGGI),
+	GWANGJU_GYEONGGI("31360", "광주시", ProvinceType.GYEONGGI),
+	YANGJU("31370", "양주시", ProvinceType.GYEONGGI),
+	POCHEON("31380", "포천시", ProvinceType.GYEONGGI),
+	YEOJU("31390", "여주시", ProvinceType.GYEONGGI),
+	YEONCHEON("31410", "연천군", ProvinceType.GYEONGGI),
+	GAPYEONG("31420", "가평군", ProvinceType.GYEONGGI),
+	YANGPYEONG("31430", "양평군", ProvinceType.GYEONGGI),
+
+	// 강원특별자치도
+	CHUNCHEON("32010", "춘천시", ProvinceType.GANGWON),
+	WONJU("32020", "원주시", ProvinceType.GANGWON),
+	GANGNEUNG("32030", "강릉시", ProvinceType.GANGWON),
+	DONGHAE("32040", "동해시", ProvinceType.GANGWON),
+	TAEBAEK("32050", "태백시", ProvinceType.GANGWON),
+	SOKCHO("32060", "속초시", ProvinceType.GANGWON),
+	SAMCHEOK("32070", "삼척시", ProvinceType.GANGWON),
+	HONGCHEON("32310", "홍천군", ProvinceType.GANGWON),
+	HOENGSEONG("32320", "횡성군", ProvinceType.GANGWON),
+	YEONGWOL("32330", "영월군", ProvinceType.GANGWON),
+	PYEONGCHANG("32340", "평창군", ProvinceType.GANGWON),
+	JEONGSEON("32350", "정선군", ProvinceType.GANGWON),
+	CHEORWON("32360", "철원군", ProvinceType.GANGWON),
+	HWACHEON("32370", "화천군", ProvinceType.GANGWON),
+	YANGGU("32380", "양구군", ProvinceType.GANGWON),
+	INJE("32390", "인제군", ProvinceType.GANGWON),
+	GOSEONG_GANGWON("32400", "고성군", ProvinceType.GANGWON),
+	YANGYANG("32410", "양양군", ProvinceType.GANGWON),
+
+	// 충청북도
+	CHEONGJU_SANGDANG("33010", "청주시 상당구", ProvinceType.CHUNGBUK),
+	CHEONGJU_SEOWON("33020", "청주시 서원구", ProvinceType.CHUNGBUK),
+	CHEONGJU_HEUNGDEOK("33030", "청주시 흥덕구", ProvinceType.CHUNGBUK),
+	CHEONGJU_CHEONGWON("33040", "청주시 청원구", ProvinceType.CHUNGBUK),
+	CHUNGJU("33050", "충주시", ProvinceType.CHUNGBUK),
+	JECHEON("33060", "제천시", ProvinceType.CHUNGBUK),
+	BOEUN("33310", "보은군", ProvinceType.CHUNGBUK),
+	OKCHEON("33320", "옥천군", ProvinceType.CHUNGBUK),
+	YEONGDONG("33330", "영동군", ProvinceType.CHUNGBUK),
+	JINCHEON("33340", "진천군", ProvinceType.CHUNGBUK),
+	GOESAN("33350", "괴산군", ProvinceType.CHUNGBUK),
+	EUMSEONG("33360", "음성군", ProvinceType.CHUNGBUK),
+	DANYANG("33370", "단양군", ProvinceType.CHUNGBUK),
+	JEUNGPYEONG("33380", "증평군", ProvinceType.CHUNGBUK),
+
+	// 충청남도
+	CHEONAN_DONGNAM("34010", "천안시 동남구", ProvinceType.CHUNGNAM),
+	CHEONAN_SEOBUK("34020", "천안시 서북구", ProvinceType.CHUNGNAM),
+	GONGJU("34030", "공주시", ProvinceType.CHUNGNAM),
+	BORYEONG("34040", "보령시", ProvinceType.CHUNGNAM),
+	ASAN("34050", "아산시", ProvinceType.CHUNGNAM),
+	SEOSAN("34060", "서산시", ProvinceType.CHUNGNAM),
+	NONSAN("34070", "논산시", ProvinceType.CHUNGNAM),
+	GYERYONG("34080", "계룡시", ProvinceType.CHUNGNAM),
+	DANGJIN("34090", "당진시", ProvinceType.CHUNGNAM),
+	GEUMSAN("34310", "금산군", ProvinceType.CHUNGNAM),
+	BUYEO("34330", "부여군", ProvinceType.CHUNGNAM),
+	SEOCHEON("34340", "서천군", ProvinceType.CHUNGNAM),
+	CHEONGYANG("34350", "청양군", ProvinceType.CHUNGNAM),
+	HONGSEONG("34360", "홍성군", ProvinceType.CHUNGNAM),
+	YESAN("34370", "예산군", ProvinceType.CHUNGNAM),
+	TAEAN("34380", "태안군", ProvinceType.CHUNGNAM),
+
+	// 전북특별자치도
+	JEONJU_WANSAN("35010", "전주시 완산구", ProvinceType.JEONBUK),
+	JEONJU_DEOKJIN("35020", "전주시 덕진구", ProvinceType.JEONBUK),
+	GUNSAN("35030", "군산시", ProvinceType.JEONBUK),
+	IKSAN("35040", "익산시", ProvinceType.JEONBUK),
+	JEONGEUP("35050", "정읍시", ProvinceType.JEONBUK),
+	NAMWON("35060", "남원시", ProvinceType.JEONBUK),
+	GIMJE("35070", "김제시", ProvinceType.JEONBUK),
+	WANJU("35310", "완주군", ProvinceType.JEONBUK),
+	JINAN("35320", "진안군", ProvinceType.JEONBUK),
+	MUJU("35330", "무주군", ProvinceType.JEONBUK),
+	JANGSU("35340", "장수군", ProvinceType.JEONBUK),
+	IMSIL("35350", "임실군", ProvinceType.JEONBUK),
+	SUNCHANG("35360", "순창군", ProvinceType.JEONBUK),
+	GOCHANG("35370", "고창군", ProvinceType.JEONBUK),
+	BUAN("35380", "부안군", ProvinceType.JEONBUK),
+
+	// 전라남도
+	MOKPO("36010", "목포시", ProvinceType.JEONNAM),
+	YEOSU("36020", "여수시", ProvinceType.JEONNAM),
+	SUNCHEON("36030", "순천시", ProvinceType.JEONNAM),
+	NAJU("36040", "나주시", ProvinceType.JEONNAM),
+	GWANGYANG("36060", "광양시", ProvinceType.JEONNAM),
+	DAMYANG("36310", "담양군", ProvinceType.JEONNAM),
+	GOKSEONG("36320", "곡성군", ProvinceType.JEONNAM),
+	GURYE("36330", "구례군", ProvinceType.JEONNAM),
+	GOHEUNG("36350", "고흥군", ProvinceType.JEONNAM),
+	BOSEONG("36360", "보성군", ProvinceType.JEONNAM),
+	HWASUN("36370", "화순군", ProvinceType.JEONNAM),
+	JANGHEUNG("36380", "장흥군", ProvinceType.JEONNAM),
+	GANGJIN("36390", "강진군", ProvinceType.JEONNAM),
+	HAENAM("36400", "해남군", ProvinceType.JEONNAM),
+	YEONGAM("36410", "영암군", ProvinceType.JEONNAM),
+	MUAN("36420", "무안군", ProvinceType.JEONNAM),
+	HAMPYEONG("36430", "함평군", ProvinceType.JEONNAM),
+	YEONGGWANG("36440", "영광군", ProvinceType.JEONNAM),
+	JANGSEONG("36450", "장성군", ProvinceType.JEONNAM),
+	WANDO("36460", "완도군", ProvinceType.JEONNAM),
+	JINDO("36470", "진도군", ProvinceType.JEONNAM),
+	SINAN("36480", "신안군", ProvinceType.JEONNAM),
+
+	// 경상북도
+	POHANG_NAM("37010", "포항시 남구", ProvinceType.GYEONGBUK),
+	POHANG_BUK("37020", "포항시 북구", ProvinceType.GYEONGBUK),
+	GYEONGJU("37030", "경주시", ProvinceType.GYEONGBUK),
+	GIMCHEON("37040", "김천시", ProvinceType.GYEONGBUK),
+	ANDONG("37050", "안동시", ProvinceType.GYEONGBUK),
+	GUMI("37060", "구미시", ProvinceType.GYEONGBUK),
+	YEONGJU("37070", "영주시", ProvinceType.GYEONGBUK),
+	YEONGCHEON("37080", "영천시", ProvinceType.GYEONGBUK),
+	SANGJU("37090", "상주시", ProvinceType.GYEONGBUK),
+	MUNGYEONG("37100", "문경시", ProvinceType.GYEONGBUK),
+	GYEONGSAN("37110", "경산시", ProvinceType.GYEONGBUK),
+	UISEONG("37310", "의성군", ProvinceType.GYEONGBUK),
+	CHEONGSONG("37320", "청송군", ProvinceType.GYEONGBUK),
+	YEONGYANG("37330", "영양군", ProvinceType.GYEONGBUK),
+	YEONGDEOK("37340", "영덕군", ProvinceType.GYEONGBUK),
+	CHEONGDO("37350", "청도군", ProvinceType.GYEONGBUK),
+	GORYEONG("37360", "고령군", ProvinceType.GYEONGBUK),
+	SEONGJU("37370", "성주군", ProvinceType.GYEONGBUK),
+	CHILGOK("37380", "칠곡군", ProvinceType.GYEONGBUK),
+	YECHEON("37390", "예천군", ProvinceType.GYEONGBUK),
+	BONGHWA("37400", "봉화군", ProvinceType.GYEONGBUK),
+	ULJIN("37410", "울진군", ProvinceType.GYEONGBUK),
+	ULLEUNG("37420", "울릉군", ProvinceType.GYEONGBUK),
+
+	// 경상남도
+	CHANGWON_UICHANG("38010", "창원시 의창구", ProvinceType.GYEONGNAM),
+	CHANGWON_SEONGSAN("38020", "창원시 성산구", ProvinceType.GYEONGNAM),
+	CHANGWON_MASANHOIPO("38030", "창원시 마산합포구", ProvinceType.GYEONGNAM),
+	CHANGWON_MASANHEWON("38040", "창원시 마산회원구", ProvinceType.GYEONGNAM),
+	CHANGWON_JINHAE("38050", "창원시 진해구", ProvinceType.GYEONGNAM),
+	JINJU("38060", "진주시", ProvinceType.GYEONGNAM),
+	TONGYEONG("38070", "통영시", ProvinceType.GYEONGNAM),
+	SACHEON("38080", "사천시", ProvinceType.GYEONGNAM),
+	GIMHAE("38090", "김해시", ProvinceType.GYEONGNAM),
+	MIRYANG("38100", "밀양시", ProvinceType.GYEONGNAM),
+	GEOJE("38110", "거제시", ProvinceType.GYEONGNAM),
+	YANGSAN("38120", "양산시", ProvinceType.GYEONGNAM),
+	UIRYEONG("38310", "의령군", ProvinceType.GYEONGNAM),
+	HAMAN("38320", "함안군", ProvinceType.GYEONGNAM),
+	CHANGNYEONG("38330", "창녕군", ProvinceType.GYEONGNAM),
+	GOSEONG_GYEONGNAM("38340", "고성군", ProvinceType.GYEONGNAM),
+	NAMHAE("38350", "남해군", ProvinceType.GYEONGNAM),
+	HADONG("38360", "하동군", ProvinceType.GYEONGNAM),
+	SANCHEONG("38370", "산청군", ProvinceType.GYEONGNAM),
+	HAMYANG("38380", "함양군", ProvinceType.GYEONGNAM),
+	GEOCHANG("38390", "거창군", ProvinceType.GYEONGNAM),
+	HAPCHEON("38400", "합천군", ProvinceType.GYEONGNAM),
+
+	// 제주특별자치도
+	JEJU_SI("39010", "제주시", ProvinceType.JEJU),
+	SEOGWIPO("39020", "서귀포시", ProvinceType.JEJU);
+
+	private final String code;
+	private final String name;
+	private final ProvinceType provinceType;
+
+	// 코드 인덱싱을 위한 정적 맵
+	private static final Map<String, DistrictType> BY_CODE = new HashMap<>();
+
+	static {
+		for (DistrictType districtType : values()) {
+			BY_CODE.put(districtType.code, districtType);
+		}
+	}
+
+	public static DistrictType fromCode(String code) {
+		DistrictType districtType = BY_CODE.get(code);
+		if (districtType == null) {
+			throw new CustomException(ErrorCode.NOT_SUPPORTED_DISTRICT);
+		}
+		return districtType;
+	}
+
+	@JsonCreator
+	public static DistrictType from(String code) {
+		return fromCode(code);
+	}
+}

--- a/src/main/java/com/debateseason_backend_v1/domain/profile/enums/ProvinceType.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/profile/enums/ProvinceType.java
@@ -1,0 +1,60 @@
+package com.debateseason_backend_v1.domain.profile.enums;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.debateseason_backend_v1.common.exception.CustomException;
+import com.debateseason_backend_v1.common.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProvinceType {
+
+	SEOUL("11", "서울특별시"),
+	BUSAN("21", "부산광역시"),
+	DAEGU("22", "대구광역시"),
+	INCHEON("23", "인천광역시"),
+	GWANGJU("24", "광주광역시"),
+	DAEJEON("25", "대전광역시"),
+	ULSAN("26", "울산광역시"),
+	SEJONG("29", "세종특별자치시"),
+	GYEONGGI("31", "경기도"),
+	GANGWON("32", "강원특별자치도"),
+	CHUNGBUK("33", "충청북도"),
+	CHUNGNAM("34", "충청남도"),
+	JEONBUK("35", "전북특별자치도"),
+	JEONNAM("36", "전라남도"),
+	GYEONGBUK("37", "경상북도"),
+	GYEONGNAM("38", "경상남도"),
+	JEJU("39", "제주특별자치도");
+
+	private final String code;
+	private final String name;
+
+	// 코드 인덱싱을 위한 정적 맵
+	private static final Map<String, ProvinceType> BY_CODE = new HashMap<>();
+
+	static {
+		for (ProvinceType provinceType : values()) {
+			BY_CODE.put(provinceType.code, provinceType);
+		}
+	}
+
+	public static ProvinceType fromCode(String code) {
+		ProvinceType provinceType = BY_CODE.get(code);
+		if (provinceType == null) {
+			throw new CustomException(ErrorCode.NOT_SUPPORTED_PROVINCE);
+		}
+		return provinceType;
+	}
+
+	@JsonCreator
+	public static ProvinceType from(String code) {
+		return fromCode(code);
+	}
+
+}

--- a/src/main/java/com/debateseason_backend_v1/domain/profile/service/ProfileServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/profile/service/ProfileServiceV1.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.debateseason_backend_v1.common.exception.CustomException;
 import com.debateseason_backend_v1.common.exception.ErrorCode;
+import com.debateseason_backend_v1.domain.profile.domain.Region;
 import com.debateseason_backend_v1.domain.profile.enums.CommunityType;
 import com.debateseason_backend_v1.domain.profile.service.request.ProfileRegisterServiceRequest;
 import com.debateseason_backend_v1.domain.profile.service.request.ProfileUpdateServiceRequest;
@@ -30,13 +31,18 @@ public class ProfileServiceV1 {
 
 		validateProfileRegistration(request);
 
+		Region residence = Region.of(request.residenceProvince(), request.residenceDistrict());
+		Region hometown = Region.of(request.hometownProvince(), request.hometownDistrict());
+
 		Profile profile = Profile.builder()
 			.userId(request.userId())
-			.profileColor(request.profileColor())
+			.profileImage(request.profileImage())
 			.nickname(request.nickname())
 			.gender(request.gender())
 			.ageRange(request.ageRange())
 			.communityId(request.communityId())
+			.residence(residence)
+			.hometown(hometown)
 			.build();
 
 		profileRepository.save(profile);
@@ -60,8 +66,12 @@ public class ProfileServiceV1 {
 
 		validateProfileUpdate(request, profile);
 
+		Region residence = Region.of(request.residenceProvince(), request.residenceDistrict());
+		Region hometown = Region.of(request.hometownProvince(), request.hometownDistrict());
+
 		profile.update(
-			request.profileColor(), request.nickname(), request.communityId(), request.gender(), request.ageRange()
+			request.profileImage(), request.nickname(), request.communityId(), request.gender(), request.ageRange(),
+			residence, hometown
 		);
 	}
 

--- a/src/main/java/com/debateseason_backend_v1/domain/profile/service/request/ProfileRegisterServiceRequest.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/profile/service/request/ProfileRegisterServiceRequest.java
@@ -1,17 +1,23 @@
 package com.debateseason_backend_v1.domain.profile.service.request;
 
 import com.debateseason_backend_v1.domain.profile.enums.AgeRangeType;
+import com.debateseason_backend_v1.domain.profile.enums.DistrictType;
 import com.debateseason_backend_v1.domain.profile.enums.GenderType;
+import com.debateseason_backend_v1.domain.profile.enums.ProvinceType;
 
 import lombok.Builder;
 
 @Builder
 public record ProfileRegisterServiceRequest(
 	Long userId,
-	String profileColor,
+	String profileImage,
 	String nickname,
 	Long communityId,
 	GenderType gender,
-	AgeRangeType ageRange
+	AgeRangeType ageRange,
+	ProvinceType residenceProvince,
+	DistrictType residenceDistrict,
+	ProvinceType hometownProvince,
+	DistrictType hometownDistrict
 ) {
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/profile/service/request/ProfileUpdateServiceRequest.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/profile/service/request/ProfileUpdateServiceRequest.java
@@ -1,17 +1,23 @@
 package com.debateseason_backend_v1.domain.profile.service.request;
 
 import com.debateseason_backend_v1.domain.profile.enums.AgeRangeType;
+import com.debateseason_backend_v1.domain.profile.enums.DistrictType;
 import com.debateseason_backend_v1.domain.profile.enums.GenderType;
+import com.debateseason_backend_v1.domain.profile.enums.ProvinceType;
 
 import lombok.Builder;
 
 @Builder
 public record ProfileUpdateServiceRequest(
 	Long userId,
-	String profileColor,
+	String profileImage,
 	String nickname,
 	Long communityId,
 	GenderType gender,
-	AgeRangeType ageRange
+	AgeRangeType ageRange,
+	ProvinceType residenceProvince,
+	DistrictType residenceDistrict,
+	ProvinceType hometownProvince,
+	DistrictType hometownDistrict
 ) {
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/profile/service/response/ProfileResponse.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/profile/service/response/ProfileResponse.java
@@ -6,11 +6,13 @@ import com.debateseason_backend_v1.domain.profile.enums.GenderType;
 import com.debateseason_backend_v1.domain.repository.entity.Profile;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
+@Builder
 @Schema(title = "내 프로필 조회 응답 DTO", description = "내 프로필 조회 응답")
 public record ProfileResponse(
-	// @Schema(description = "프로필 컬러", example = "RED")
-	// String profileColor,
+	@Schema(description = "프로필 이미지", example = "RED")
+	String profileImage,
 
 	@Schema(description = "닉네임", example = "토론왕")
 	String nickname,
@@ -22,18 +24,34 @@ public record ProfileResponse(
 	AgeRangeType ageRange,
 
 	@Schema(description = "프로필에 등록된 커뮤니티 응답")
-	CommunityResponse community
+	CommunityResponse community,
+
+	@Schema(description = "거주 시도 코드", example = "11")
+	String residenceProvince,
+
+	@Schema(description = "거주 시군구 코드", example = "11030")
+	String residenceDistrict,
+
+	@Schema(description = "출신 시도 코드", example = "21")
+	String hometownProvince,
+
+	@Schema(description = "출신 시군구 코드", example = "21010")
+	String hometownDistrict
 ) {
 
 	public static ProfileResponse of(Profile profile, CommunityType communityType) {
 
-		return new ProfileResponse(
-			// profile.getProfileColor(),
-			profile.getNickname(),
-			profile.getGender(),
-			profile.getAgeRange(),
-			CommunityResponse.from(communityType)
-		);
+		return ProfileResponse.builder()
+			.profileImage(profile.getProfileImage())
+			.nickname(profile.getNickname())
+			.gender(profile.getGender())
+			.ageRange(profile.getAgeRange())
+			.residenceProvince(profile.getResidence().getProvinceType().getCode())
+			.residenceDistrict(profile.getResidence().getDistrictType().getCode())
+			.hometownProvince(profile.getHometown().getProvinceType().getCode())
+			.hometownDistrict(profile.getHometown().getDistrictType().getCode())
+			.community(CommunityResponse.from(communityType))
+			.build();
 	}
 
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Profile.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/Profile.java
@@ -5,11 +5,15 @@ import java.time.LocalDateTime;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import com.debateseason_backend_v1.domain.profile.domain.Region;
 import com.debateseason_backend_v1.domain.profile.enums.AgeRangeType;
 import com.debateseason_backend_v1.domain.profile.enums.CommunityType;
 import com.debateseason_backend_v1.domain.profile.enums.GenderType;
 
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
@@ -38,8 +42,8 @@ public class Profile {
 	@Column(name = "user_id")
 	private Long userId;
 
-	@Column(name = "profile_color")
-	private String profileColor;
+	@Column(name = "profile_image")
+	private String profileImage;
 
 	@Column(name = "nickname", unique = true)
 	private String nickname;
@@ -55,32 +59,52 @@ public class Profile {
 	@Column(name = "age_range")
 	private AgeRangeType ageRange;
 
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "provinceType", column = @Column(name = "residence_province")),
+		@AttributeOverride(name = "districtType", column = @Column(name = "residence_district"))
+	})
+	private Region residence;
+
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "provinceType", column = @Column(name = "hometown_province")),
+		@AttributeOverride(name = "districtType", column = @Column(name = "hometown_district"))
+	})
+	private Region hometown;
+
 	@LastModifiedDate
 	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
 
 	@Builder
 	private Profile(
-		Long userId, String profileColor, String nickname, Long communityId, GenderType gender, AgeRangeType ageRange
+		Long userId, String profileImage, String nickname, Long communityId, GenderType gender, AgeRangeType ageRange,
+		Region residence, Region hometown
 	) {
 
 		this.userId = userId;
-		this.profileColor = profileColor;
+		this.profileImage = profileImage;
 		this.nickname = nickname;
 		this.communityId = communityId;
 		this.gender = gender;
 		this.ageRange = ageRange;
+		this.residence = residence;
+		this.hometown = hometown;
 	}
 
 	public void update(
-		String profileColor, String nickname, Long communityId, GenderType gender, AgeRangeType ageRange
+		String profileImage, String nickname, Long communityId, GenderType gender, AgeRangeType ageRange,
+		Region residence, Region hometown
 	) {
 
-		this.profileColor = profileColor;
+		this.profileImage = profileImage;
 		this.nickname = nickname;
 		this.communityId = communityId;
 		this.gender = gender;
 		this.ageRange = ageRange;
+		this.residence = residence;
+		this.hometown = hometown;
 	}
 
 	public void anonymize(String anonymousNickname) {

--- a/src/test/java/com/debateseason_backend_v1/domain/profile/service/ProfileServiceV1Test.java
+++ b/src/test/java/com/debateseason_backend_v1/domain/profile/service/ProfileServiceV1Test.java
@@ -16,8 +16,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.debateseason_backend_v1.common.exception.CustomException;
 import com.debateseason_backend_v1.common.exception.ErrorCode;
+import com.debateseason_backend_v1.domain.profile.domain.Region;
 import com.debateseason_backend_v1.domain.profile.enums.AgeRangeType;
+import com.debateseason_backend_v1.domain.profile.enums.DistrictType;
 import com.debateseason_backend_v1.domain.profile.enums.GenderType;
+import com.debateseason_backend_v1.domain.profile.enums.ProvinceType;
 import com.debateseason_backend_v1.domain.profile.service.request.ProfileRegisterServiceRequest;
 import com.debateseason_backend_v1.domain.profile.service.request.ProfileUpdateServiceRequest;
 import com.debateseason_backend_v1.domain.profile.service.response.ProfileResponse;
@@ -221,7 +224,7 @@ class ProfileServiceV1Test {
 			ProfileUpdateServiceRequest request = createUpdateRequest();
 			Profile profile = Profile.builder()
 				.userId(1L)
-				.profileColor("RED")
+				.profileImage("RED")
 				.nickname("기존닉네임")
 				.communityId(1L)
 				.gender(GenderType.MALE)
@@ -248,16 +251,20 @@ class ProfileServiceV1Test {
 			String sameNickname = "토론왕";
 			ProfileUpdateServiceRequest request = ProfileUpdateServiceRequest.builder()
 				.userId(1L)
-				.profileColor("RED")
+				.profileImage("RED")
 				.nickname(sameNickname)
 				.communityId(1L)
 				.gender(GenderType.MALE)
 				.ageRange(AgeRangeType.TWENTIES)
+				.hometownDistrict(DistrictType.YONGSAN)
+				.hometownProvince(ProvinceType.SEOUL)
+				.residenceDistrict(DistrictType.YONGSAN)
+				.residenceProvince(ProvinceType.SEOUL)
 				.build();
 
 			Profile profile = Profile.builder()
 				.userId(1L)
-				.profileColor("RED")
+				.profileImage("RED")
 				.nickname(sameNickname)
 				.communityId(1L)
 				.gender(GenderType.MALE)
@@ -332,33 +339,43 @@ class ProfileServiceV1Test {
 	private ProfileRegisterServiceRequest createRegisterRequest() {
 		return ProfileRegisterServiceRequest.builder()
 			.userId(1L)
-			.profileColor("RED")
+			.profileImage("RED")
 			.nickname("토론왕")
 			.communityId(1L)
 			.gender(GenderType.MALE)
 			.ageRange(AgeRangeType.TWENTIES)
+			.hometownDistrict(DistrictType.YONGSAN)
+			.hometownProvince(ProvinceType.SEOUL)
+			.residenceDistrict(DistrictType.YONGSAN)
+			.residenceProvince(ProvinceType.SEOUL)
 			.build();
 	}
 
 	private ProfileUpdateServiceRequest createUpdateRequest() {
 		return ProfileUpdateServiceRequest.builder()
 			.userId(1L)
-			.profileColor("BLUE")
+			.profileImage("BLUE")
 			.nickname("토론왕2")
 			.communityId(2L)
 			.gender(GenderType.FEMALE)
 			.ageRange(AgeRangeType.THIRTIES)
+			.hometownDistrict(DistrictType.YONGSAN)
+			.hometownProvince(ProvinceType.SEOUL)
+			.residenceDistrict(DistrictType.YONGSAN)
+			.residenceProvince(ProvinceType.SEOUL)
 			.build();
 	}
 
 	private Profile createProfile() {
 		return Profile.builder()
 			.userId(1L)
-			.profileColor("RED")
+			.profileImage("RED")
 			.nickname("토론왕")
 			.communityId(1L)
 			.gender(GenderType.MALE)
 			.ageRange(AgeRangeType.TWENTIES)
+			.hometown(Region.of(ProvinceType.SEOUL, DistrictType.YONGSAN))
+			.residence(Region.of(ProvinceType.SEOUL, DistrictType.YONGSAN))
 			.build();
 	}
 }

--- a/src/test/java/com/debateseason_backend_v1/domain/repository/entity/ProfileTest.java
+++ b/src/test/java/com/debateseason_backend_v1/domain/repository/entity/ProfileTest.java
@@ -5,9 +5,12 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.debateseason_backend_v1.domain.profile.domain.Region;
 import com.debateseason_backend_v1.domain.profile.enums.AgeRangeType;
 import com.debateseason_backend_v1.domain.profile.enums.CommunityType;
+import com.debateseason_backend_v1.domain.profile.enums.DistrictType;
 import com.debateseason_backend_v1.domain.profile.enums.GenderType;
+import com.debateseason_backend_v1.domain.profile.enums.ProvinceType;
 
 class ProfileTest {
 
@@ -25,7 +28,7 @@ class ProfileTest {
 		// when
 		Profile profile = Profile.builder()
 			.userId(userId)
-			.profileColor(profileColor)
+			.profileImage(profileColor)
 			.nickname(nickname)
 			.communityId(communityId)
 			.gender(gender)
@@ -34,7 +37,7 @@ class ProfileTest {
 
 		// then
 		assertThat(profile.getUserId()).isEqualTo(userId);
-		assertThat(profile.getProfileColor()).isEqualTo(profileColor);
+		assertThat(profile.getProfileImage()).isEqualTo(profileColor);
 		assertThat(profile.getNickname()).isEqualTo(nickname);
 		assertThat(profile.getCommunityId()).isEqualTo(communityId);
 		assertThat(profile.getGender()).isEqualTo(gender);
@@ -47,24 +50,28 @@ class ProfileTest {
 		// given
 		Profile profile = Profile.builder()
 			.userId(1L)
-			.profileColor("RED")
+			.profileImage("RED")
 			.nickname("토론왕")
 			.communityId(1L)
 			.gender(GenderType.MALE)
 			.ageRange(AgeRangeType.TWENTIES)
+			.hometown(Region.of(ProvinceType.SEOUL, DistrictType.YONGSAN))
+			.residence(Region.of(ProvinceType.SEOUL, DistrictType.YONGSAN))
 			.build();
 
-		String newProfileColor = "BLUE";
+		String newProfileImage = "BLUE";
 		String newNickname = "토론마스터";
 		Long newCommunityId = 2L;
 		GenderType newGender = GenderType.FEMALE;
 		AgeRangeType newAgeRange = AgeRangeType.THIRTIES;
+		Region newHometown = Region.of(ProvinceType.BUSAN, DistrictType.JUNG_BUSAN);
+		Region newResidence = Region.of(ProvinceType.BUSAN, DistrictType.JUNG_BUSAN);
 
 		// when
-		profile.update(newProfileColor, newNickname, newCommunityId, newGender, newAgeRange);
+		profile.update(newProfileImage, newNickname, newCommunityId, newGender, newAgeRange, newHometown, newResidence);
 
 		// then
-		assertThat(profile.getProfileColor()).isEqualTo(newProfileColor);
+		assertThat(profile.getProfileImage()).isEqualTo(newProfileImage);
 		assertThat(profile.getNickname()).isEqualTo(newNickname);
 		assertThat(profile.getCommunityId()).isEqualTo(newCommunityId);
 		assertThat(profile.getGender()).isEqualTo(newGender);
@@ -77,11 +84,13 @@ class ProfileTest {
 		// given
 		Profile profile = Profile.builder()
 			.userId(1L)
-			.profileColor("RED")
+			.profileImage("RED")
 			.nickname("토론왕")
 			.communityId(1L)
 			.gender(GenderType.MALE)
 			.ageRange(AgeRangeType.TWENTIES)
+			.hometown(Region.of(ProvinceType.SEOUL, DistrictType.YONGSAN))
+			.residence(Region.of(ProvinceType.SEOUL, DistrictType.YONGSAN))
 			.build();
 
 		String anonymousNickname = "탈퇴한사용자";
@@ -101,11 +110,13 @@ class ProfileTest {
 		Long communityId = 1L; // DC_INSIDE
 		Profile profile = Profile.builder()
 			.userId(1L)
-			.profileColor("RED")
+			.profileImage("RED")
 			.nickname("토론왕")
 			.communityId(communityId)
 			.gender(GenderType.MALE)
 			.ageRange(AgeRangeType.TWENTIES)
+			.hometown(Region.of(ProvinceType.SEOUL, DistrictType.YONGSAN))
+			.residence(Region.of(ProvinceType.SEOUL, DistrictType.YONGSAN))
 			.build();
 
 		// when
@@ -123,11 +134,13 @@ class ProfileTest {
 		// given
 		Profile profile = Profile.builder()
 			.userId(1L)
-			.profileColor("RED")
+			.profileImage("RED")
 			.nickname("토론왕")
 			.communityId(null)
 			.gender(GenderType.MALE)
 			.ageRange(AgeRangeType.TWENTIES)
+			.hometown(Region.of(ProvinceType.SEOUL, DistrictType.YONGSAN))
+			.residence(Region.of(ProvinceType.SEOUL, DistrictType.YONGSAN))
 			.build();
 
 		// when


### PR DESCRIPTION
## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
프로필 추가 정보 입력 구현

## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
1. 프로필의 색상, 거주지 정보를 추가하는 기능을 구현했습니다.
* https://www.notion.so/1ac034a1724480e69636fa9484e6381e?source=copy_link
* https://www.notion.so/1ac034a1724480bc9ce7c7e7efcf6ced?source=copy_link

업데이트를 하지 않은 유저를 고려해 API의 요청에 필수 입력 제한은 풀었습니다.


## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->

