### PR TITLE
hotfix: Grace Period 토큰 재발급 적용

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/RefreshTokenRepository.java
@@ -15,15 +15,15 @@ import jakarta.persistence.LockModeType;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	@Query("SELECT rt FROM RefreshToken rt WHERE rt.token = :token")
-	Optional<RefreshToken> findByToken(@Param("token") String token);
+	@Query("SELECT rt FROM RefreshToken rt WHERE rt.currentToken = :token OR rt.previousToken = :token")
+	Optional<RefreshToken> findByCurrentTokenOrPreviousToken(@Param("token") String token);
 
-	void deleteByToken(String token);
+	void deleteByCurrentToken(String token);
 
 	@Modifying
 	@Query("DELETE FROM RefreshToken rt WHERE rt.userId = :userId")
 	void deleteAllByUserId(Long userId);
 
-	boolean existsByToken(String token);
+	boolean existsByCurrentToken(String token);
 
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/RefreshToken.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/RefreshToken.java
@@ -32,14 +32,14 @@ public class RefreshToken {
 	@Column(name = "refresh_token_id")
 	private Long id;
 
-	@Version
-	private Long version;
-
 	@JoinColumn(name = "user_id", nullable = false)
 	private Long userId;
 
-	@Column(name = "token")
-	private String token;
+	@Column(name = "current_token", unique = true, nullable = false)
+	private String currentToken;
+
+	@Column(name = "previou_token", unique = true, nullable = false)
+	private String previousToken;
 
 	@CreatedDate
 	@Column(name = "created_at", updatable = false)
@@ -50,20 +50,22 @@ public class RefreshToken {
 	private LocalDateTime updatedAt;
 
 	@Builder
-	private RefreshToken(Long userId, String token) {
-		this.userId = userId;
-		this.token = token;
+	private RefreshToken(Long userId, String currentToken, String previousToken) {
+		this.userId = userId ;
+		this.currentToken = currentToken;
+		this.previousToken = previousToken;
 	}
 
-	public static RefreshToken create(Long userId, String token) {
+	public static RefreshToken create(Long userId, String currentToken, String previousToken) {
 		return RefreshToken.builder()
 			.userId(userId)
-			.token(token)
+			.currentToken(currentToken)
+			.previousToken(previousToken)
 			.build();
 	}
 
-	public void updateToken(String token) {
-		this.token = token;
+	public void update(String newToken) {
+		this.previousToken = this.currentToken;
+		this.currentToken = newToken;
 	}
-
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/user/application/service/UserServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/application/service/UserServiceV1.java
@@ -47,7 +47,7 @@ public class UserServiceV1 {
 
 		String accessToken = jwtUtil.createAccessToken(user.getId());
 		String refreshToken = jwtUtil.createRefreshToken(user.getId());
-		RefreshToken token = RefreshToken.create(user.getId(), refreshToken);
+		RefreshToken token = RefreshToken.create(user.getId(), refreshToken, refreshToken);
 
 		refreshTokenRepository.save(token);
 
@@ -66,7 +66,7 @@ public class UserServiceV1 {
 	@Transactional
 	public void logout(LogoutServiceRequest request) {
 
-		if (!refreshTokenRepository.existsByToken(request.refreshToken())) {
+		if (!refreshTokenRepository.existsByCurrentToken(request.refreshToken())) {
 			throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
 		}
 
@@ -78,7 +78,7 @@ public class UserServiceV1 {
 			throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
 		}
 
-		refreshTokenRepository.deleteByToken(request.refreshToken());
+		refreshTokenRepository.deleteByCurrentToken(request.refreshToken());
 	}
 
 	@Transactional

--- a/src/main/java/com/debateseason_backend_v1/domain/user/application/service/UserServiceV2.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/application/service/UserServiceV2.java
@@ -44,7 +44,7 @@ public class UserServiceV2 {
 
 		String accessToken = jwtUtil.createAccessToken(user.getId());
 		String refreshToken = jwtUtil.createRefreshToken(user.getId());
-		RefreshToken token = RefreshToken.create(user.getId(), refreshToken);
+		RefreshToken token = RefreshToken.create(user.getId(), refreshToken, refreshToken);
 
 		refreshTokenRepository.save(token);
 


### PR DESCRIPTION
## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
Access Token 재발급시 발생하는 동시성 이슈 문제를 해결하기 위한 작업

## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
### 1. 여러 API에서 요청하는 Access Token 재발급 요청
새롭게 추가된 화면을 그리기 위해 프론트단에서 여러 API를 호출합니다.
그 과정에서 Access Token이 만료됐을 시 여러 API에서 발생한 에러를 Interceptor가 잡아 동시에 여러 번의 토큰 재발급 API를 호출합니다.
이때, 모든 요청은 기존의 refresh token을 요청 값으로 보내지만, 첫 번째로 응답을 되는 요청에 의해 이미 Refresh Token이 업데이트가 되고,
이로 인해 나머지 재발급 요청은 실패해(데이터베이스에 일치하는 Refresh Token이 없어서) 로그아웃 처리가 되는 문제가 발생했습니다.
이를 해결하기 현재의 Refresh Token과 이전의 Refresh Token 두 가지를 데이터베이스에 저장하고 짧은 Grace Period(유예 기간)을 두어 
유예 기간 안에 들어오는 요청은 Refresh Token을 로테이션 하지 않고 access Token만 발급하는 로직으로 변경했습니다.
(refresh token을 조회시 `currentToken` 또는 `previousToken`과 일치하는 토큰을 조회함.)

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->

