### PR TITLE
feat: JaCoCo  테스트 커버리지 도구 도입 및 설정 최적화 #141

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.5'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'jacoco'
 }
 
 group = 'com.debateseason_v1'
@@ -80,9 +81,136 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:2.19.0")
 }
 
+jacoco {
+    toolVersion = "0.8.13"
+}
+
+tasks.jacocoTestReport {
+    dependsOn test
+    
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = false
+        
+        xml.outputLocation = file("$buildDir/reports/jacoco/test/jacocoTestReport.xml")
+        html.outputLocation = file("$buildDir/reports/jacoco/test/html")
+    }
+    //자코 테스트 제외 설정
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                // 애플리케이션 및 설정 관련
+                '**/*Application*',
+                '**/config/**',
+                
+                // 엔티티 및 인프라 관련
+                '**/entity/**',
+                '**/infrastructure/*Entity*',
+                '**/*Entity*',
+                '**/domain/*/infrastructure/**',
+                
+                // DTO, Request, Response 관련
+                '**/dto/**',
+                '**/request/**',
+                '**/response/**',
+                '**/*Request*',
+                '**/*Response*',
+                '**/*DTO*',
+                '**/*Dto*',
+                
+                // Enum 및 Type 관련
+                '**/enums/**',
+                '**/*Type*',
+                
+                // 예외 및 에러 관련
+                '**/exception/**',
+                '**/*Exception*',
+                '**/error/**',
+                '**/security/error/**',
+                
+                // 문서화 관련
+                '**/docs/**',
+                '**/*Docs*',
+                '**/swagger/**',
+                
+                // 매퍼 관련
+                '**/*Mapper*',
+                '**/youtubeLive/scheduler/mapper/**',
+                
+                // 보안 관련
+                '**/security/component/**',
+                '**/security/jwt/**',
+                
+                // 스케줄러 및 검증 관련
+                '**/scheduler/**',
+                '**/validation/**',
+                
+                // 컴포넌트, 이벤트, 리스너 관련
+                '**/component/**',
+                '**/event/**',
+                '**/listener/**',
+                
+                // 레포지토리 관련
+                '**/*Repository*',
+                '**/*JpaRepository*',
+                '**/app/repository/**',
+                
+                // 공통 모듈 관련
+                '**/common/response/**',
+                '**/common/swagger/**',
+                '**/common/component/**',
+                // 특정 도메인 인프라 제외
+                '**/domain/*/infrastructure/**',
+                '**/youtubeLive/scheduler/mapper/**',
+                '**/media/infrastructure/**',
+                '**/app/repository/**',
+                '**/media/infrastructure/**'
+            ])
+        }))
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    
+    violationRules {
+        rule {
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.70
+            }
+        }
+        
+        rule {
+            element = 'PACKAGE'
+            includes = [
+                'com.debateseason_backend_v1.domain.*.service.*',
+                'com.debateseason_backend_v1.domain.*.application.service.*'
+            ]
+            limit {
+                counter = 'LINE'  
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+        }
+    }
+}
 
 tasks.named('test') {
     useJUnitPlatform()
+    
+    finalizedBy jacocoTestReport
+}
+
+tasks.register('coverageReport') {
+    dependsOn 'jacocoTestReport'
+    doLast {
+        println "📊 테스트 커버리지 리포트가 생성되었습니다!"
+        println "📁 HTML 리포트: build/reports/jacoco/test/html/index.html"
+        println "📄 XML 리포트: build/reports/jacoco/test/jacocoTestReport.xml"
+    }
 }
 
 bootJar {


### PR DESCRIPTION
## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
버그 발견 지연(운영리스크), 리팩토링 시 불안감(개발속도 저하) 등의 저의에게 지속적으로 발생하고 있는 문제를 개선하기위한 도구로  JaCoCo 테스트 커버리지 도구를 도입하고, 의미있는 코드에 대한 커버리지 기준을 설정했습니다.

## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #141 

## ✨ 작업 내용
1. **JaCoCo 플러그인 설정 추가**
   - Gradle에 JaCoCo 플러그인 추가 (`jacoco` plugin)
   - JaCoCo 버전 0.8.13 설정

2. **테스트 리포트 생성 설정**
   - HTML 리포트: 개발자 친화적 시각화 (`build/reports/jacoco/test/html/`)
   - XML 리포트: CI/CD 도구 연동용 (`build/reports/jacoco/test/jacocoTestReport.xml`)
   - CSV 리포트: 비활성화

3. **커버리지 제외 규칙 설정**
   - **제외 대상**: Entity, DTO, Request/Response, Config, Exception, Docs, Mapper, Repository 등 #141  참고
   - **포함 대상**: Service, Controller 등 핵심 비즈니스 로직
   - **목적**: 의미있는 코드에만 집중하여 정확한 품질 측정

4. **커버리지 검증 규칙 적용**
   - **전체 프로젝트**: 최소 70% 커버리지
   - **Service 패키지**: 최소 80% 커버리지 (핵심 비즈니스 로직 강화)

5. **자동화 설정**
   - 테스트 실행 시 자동 리포트 생성 (`finalizedBy jacocoTestReport`)
   - 편의 명령어 추가 (`coverageReport` task)

## 🛠️ 사용법
```bash
# 테스트 실행 및 커버리지 리포트 생성
./gradlew test

# 커버리지 리포트만 생성
./gradlew coverageReport

# 커버리지 검증 실행
./gradlew jacocoTestCoverageVerification
```

## 📊 리포트 확인
- **HTML 리포트**: `build/reports/jacoco/test/html/index.html`
- **XML 리포트**: `build/reports/jacoco/test/jacocoTestReport.xml`

> 테스트를 실행하면 자동으로 아래 경로에 최신화 됩니다.
#### `build/reports/jacoco/test/html/index.html` 경로에서 다음과같이 저희 프로젝트의 테스트 커버리지를 html로 확인 할 수  있습니다. 
![image](https://github.com/user-attachments/assets/6763a344-89eb-44a9-b5ce-099192feb4e5)

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->
- 커버리지 기준 미달 시 빌드가 실패합니다
- 새로운 Service 클래스 추가 시 반드시 테스트 코드 작성 필요
- 제외 규칙에 새로운 패턴이 필요하면 `build.gradle`의 `exclude` 섹션 수정
