### PR TITLE
fix:초기 time은 null -> 빈문자열

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/domain/chatroom/domain/TimeProcessor.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chatroom/domain/TimeProcessor.java
@@ -20,7 +20,7 @@ public class TimeProcessor {
 	public String findLastestChatTime(Long chatRoomId){
 		Optional<LocalDateTime> latestChat = chatRepository.findMostRecentMessageTimestampByChatRoomId(chatRoomId);
 
-		String time = null;
+		String time = "";// 최초 생성인 경우 빈 문자열로 응답.
 
 		if(latestChat.isPresent()){
 			// 몇 분이 지났는지.

--- a/src/main/java/com/debateseason_backend_v1/domain/chatroom/infrastructure/entity/ChatRoomProcessor.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chatroom/infrastructure/entity/ChatRoomProcessor.java
@@ -14,8 +14,10 @@ import com.debateseason_backend_v1.domain.chatroom.model.response.chatroom.type.
 import com.debateseason_backend_v1.domain.repository.ChatRoomRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 // DB에서 가져온 데이터 가공 -> DTO로 변환
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ChatRoomProcessor {

--- a/src/main/java/com/debateseason_backend_v1/domain/chatroom/service/ChatRoomServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chatroom/service/ChatRoomServiceV1.java
@@ -334,9 +334,9 @@ public class ChatRoomServiceV1 {
 
 	// 4. 투표한 여러 채팅방 가져오기
 	public ApiResult<ResponseOnlyHome> findVotedChatRoom(Long userId,Long pageChatRoomId){
+		log.info("/api/v1/home/refesh 실행");
 
 		// 0. 속보 가져오기
-
 		List<BreakingNewsResponse> breakingNews = mediaJpaRepository.findTop10BreakingNews().stream()
 			.map(
 				e->
@@ -346,10 +346,10 @@ public class ChatRoomServiceV1 {
 					.build()
 			).toList()
 			;
-
+		log.info("1.breakingNews 가져오기");
 
 		List<Top5BestChatRoom> top5BestChatRooms = chatRoomProcessor.getTop5ActiveRooms();
-
+		log.info("2.뜨겁게 논쟁 중인 찬반토론");
 		// 2. 활성화된 최상위 5개 이슈방을 보여준다.
 		// issue_id, COUNT(ch.chat_room_id)
 
@@ -357,6 +357,7 @@ public class ChatRoomServiceV1 {
 		List<Long> issueIds = issueJpaRepository.findTop5ActiveIssuesByCountingChats().stream().map(
 			e-> (Long)e[0]
 		).toList();
+		log.info("3.최상위 5개의 이슈 id값 가져오기");
 
 		// ui1.issue_id, ui1.title, ui1.created_at, ui1.chat_room_count, COUNT(ui2.issue_id) AS bookmarks
 		List<IssueBriefResponse> top5BestIssueRooms = issueJpaRepository.findIssuesWithBookmarksOrderByCreatedDate(issueIds).stream().map(
@@ -382,21 +383,24 @@ public class ChatRoomServiceV1 {
 
 			}
 		).toList();
+		log.info("4.이런 이슈는 어때요?");
 
 
 		List<Long> chatRoomIds;
 		// 첫 페이지
 		if(pageChatRoomId==null){
 			chatRoomIds = userChatRoomRepository.findTop2ChatRoomIdsByUserId(userId);
+			log.info("5. 채팅방id값 가져오기");
 		}
 		else{
 			// 그 이후 페이지
 			chatRoomIds = userChatRoomRepository.findTop2ChatRoomIdsByUserIdAndChatRoomId(userId,pageChatRoomId);
+			log.info("5. 채팅방id값 가져오기");
 		}
 
 
 		List<Object[]> chatRoomList = userChatRoomRepository.findChatRoomWithOpinions(userId,chatRoomIds);
-
+		log.info("6. 참여 중인 토론 가져오기");
 		// 아직 투표한 방이 없어서 아무것도 없는 상태로 가져올 수 있다.
 		if (chatRoomList.isEmpty()){
 
@@ -407,6 +411,8 @@ public class ChatRoomServiceV1 {
 				.top5BestIssueRooms(top5BestIssueRooms)
 				.build()
 				;
+
+			log.info("7. 응답값 반환");
 
 			return ApiResult.<ResponseOnlyHome>builder()
 				.status(200)
@@ -449,6 +455,7 @@ public class ChatRoomServiceV1 {
 
 			}
 		).collect(Collectors.toList());
+		log.info("7. 참여 중인 토론 DTO만들기");
 
 		ResponseOnlyHome responseOnlyHome = ResponseOnlyHome.builder()
 			.breakingNews(null)
@@ -457,7 +464,7 @@ public class ChatRoomServiceV1 {
 			.chatRoomResponse(fetchedChatRoomList)
 			.build()
 			;
-
+		log.info("8. ApiResult 응답값 생성.");
 
 		return ApiResult.<ResponseOnlyHome>builder()
 			.status(200)


### PR DESCRIPTION
## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
채팅방 초기 생성 시, time이 null이어서 오류가 발생한 것으로 추정.
따라서, 초기 생성시 time은 빈 문자열로 수정

오류 발생 지점을 추적하기 위해서 채팅방 api의 서비스 로직에 log 추가.

## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
1.
2.
3.

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수하였나요?
- [ ] 불필요한 코드가 남아있지 않나요?
- [ ] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->

