### PR TITLE
refactor: 채팅메시지 조회 N+1 문제 개선

### DIFF
--- a/.github/workflows/DEV_CICD.yml
+++ b/.github/workflows/DEV_CICD.yml
@@ -78,7 +78,7 @@ jobs:
           path: build/test-results/test/*.xml
           reporter: java-junit
 
-      - name: Upload test results₩
+      - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/PROD_CICD.yml
+++ b/.github/workflows/PROD_CICD.yml
@@ -78,7 +78,7 @@ jobs:
           path: build/test-results/test/*.xml
           reporter: java-junit
 
-      - name: Upload test results₩
+      - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/application/repository/ChatReactionRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/application/repository/ChatReactionRepository.java
@@ -4,7 +4,9 @@ import com.debateseason_backend_v1.domain.chat.infrastructure.chat_reaction.Chat
 import com.debateseason_backend_v1.domain.chat.presentation.dto.chat.request.ChatReactionRequest;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public interface ChatReactionRepository {
 
@@ -22,5 +24,24 @@ public interface ChatReactionRepository {
 
     void deleteByChatIdAndUserIdAndReactionType(Long chatId, Long userId, ChatReactionRequest.ReactionType reactionType);
 
+    /**
+     * 여러 채팅의 반응 수를 한 번에 조회
+     *
+     * @param chatIds 조회할 채팅 ID 목록
+     * @return Map<채팅ID, Map<반응타입, 반응수>>
+     *
+     */
+    Map<Long, Map<ChatReactionRequest.ReactionType, Integer>> findReactionCountsByChatIdsIn(List<Long> chatIds);
+
+
+    /**
+     * 특정 사용자가 여러 채팅에 남긴 반응을 한 번에 조회
+     *
+     * @param chatIds 조회할 채팅 ID 목록
+     * @param userId 사용자 ID
+     * @return Map<채팅ID, Set<반응타입>>
+     *
+     */
+    Map<Long, Set<ChatReactionRequest.ReactionType>> findUserReactionsByChatIdsIn(List<Long> chatIds, Long userId);
 
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/application/service/ChatServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/application/service/ChatServiceV1.java
@@ -204,7 +204,7 @@ public class ChatServiceV1 {
 				.collect(Collectors.toSet());
 
 		// 디버깅 로그 추가
-		log.info("@@ 승인된 신고 메시지 ID 목록: {}", acceptedReportChatIds);
+		log.debug("@@ 승인된 신고 메시지 ID 목록: {}", acceptedReportChatIds);
 
 		List<ChatMessageResponse> messageResponses = displayChats.stream()
 				.map(chatEntity -> {

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/infrastructure/chat_reaction/ChatReactionJpaRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/infrastructure/chat_reaction/ChatReactionJpaRepository.java
@@ -1,5 +1,6 @@
 package com.debateseason_backend_v1.domain.chat.infrastructure.chat_reaction;
 
+import com.debateseason_backend_v1.domain.chat.presentation.dto.chat.ReactionCountDto;
 import com.debateseason_backend_v1.domain.chat.presentation.dto.chat.request.ChatReactionRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -29,5 +30,31 @@ public interface ChatReactionJpaRepository extends JpaRepository<ChatReaction, L
 
     // 사용자의  반응 삭제
     void deleteByChatIdAndUserIdAndReactionType(Long chatId, Long userId, ChatReactionRequest.ReactionType reactionType);
+
+    /**
+     *  chatId 로 메시지 반응 조회
+     */
+    @Query("""
+        select new com.debateseason_backend_v1.domain.chat.presentation.dto.chat.ReactionCountDto(
+            cr.chat.id,
+            cr.reactionType,
+            count(cr)
+            )
+        from ChatReaction cr
+        where cr.chat.id IN :chatIds
+        group by cr.chat.id, cr.reactionType
+    """)
+    List<ReactionCountDto> findReactionCountsByChatIdsIn(@Param("chatIds") List<Long> chatIds);
+
+    /**
+     *  사용자의 반응
+     */
+    @Query("""
+        select cr
+        from ChatReaction cr
+        where cr.chat.id in :chatIds
+        and cr.userId = :userId
+    """)
+    List<ChatReaction> findUserReactionsByChatIdsIn(@Param("chatIds") List<Long> chatIds, @Param("userId") Long userId);
 
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/infrastructure/chat_reaction/ChatReactionRepositoryImpl.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/infrastructure/chat_reaction/ChatReactionRepositoryImpl.java
@@ -1,13 +1,16 @@
 package com.debateseason_backend_v1.domain.chat.infrastructure.chat_reaction;
 
 import com.debateseason_backend_v1.domain.chat.application.repository.ChatReactionRepository;
+import com.debateseason_backend_v1.domain.chat.presentation.dto.chat.ReactionCountDto;
 import com.debateseason_backend_v1.domain.chat.presentation.dto.chat.request.ChatReactionRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
+@Slf4j
 @RequiredArgsConstructor
 @Repository
 public class ChatReactionRepositoryImpl implements ChatReactionRepository {
@@ -48,4 +51,45 @@ public class ChatReactionRepositoryImpl implements ChatReactionRepository {
     public void deleteByChatIdAndUserIdAndReactionType(Long chatId, Long userId, ChatReactionRequest.ReactionType reactionType) {
         chatReactionJpaRepository.deleteByChatIdAndUserIdAndReactionType(chatId, userId, reactionType);
     }
+
+    @Override
+    public Map<Long, Map<ChatReactionRequest.ReactionType, Integer>> findReactionCountsByChatIdsIn(List<Long> chatIds){
+        if (chatIds == null || chatIds.isEmpty()) {
+            log.error("@@ chatIds가 null or empty 입니다.");
+            log.error("@@ chatIds = {}", chatIds);
+            return Collections.emptyMap();
+        }
+
+        List<ReactionCountDto> counts = chatReactionJpaRepository.findReactionCountsByChatIdsIn(chatIds);
+
+        return counts.stream()
+                .collect(Collectors.groupingBy(
+                        ReactionCountDto::getChatId,                    // 외부 Map의 키: chatId
+                        Collectors.toMap(
+                                ReactionCountDto::getReactionType,          // 내부 Map의 키: reactionType
+                                dto -> dto.getCount().intValue(),           // 내부 Map의 값: count
+                                (existing, replacement) -> existing         // 중복 키 처리 (발생하지 않아야 함)
+                        )
+                ));
+
+    }
+
+    @Override
+    public Map<Long, Set<ChatReactionRequest.ReactionType>> findUserReactionsByChatIdsIn(List<Long> chatIds, Long userId){
+        if (chatIds == null || chatIds.isEmpty() || userId == null) {
+            return Collections.emptyMap();
+        }
+
+        List<ChatReaction> userReactions = chatReactionJpaRepository.findUserReactionsByChatIdsIn(chatIds, userId);
+
+        return userReactions.stream()
+                .collect(Collectors.groupingBy(
+                        chatReaction -> chatReaction.getChat().getId(),
+                        Collectors.mapping(
+                                ChatReaction::getReactionType,
+                                Collectors.toSet()
+                        )
+                ));
+    }
+
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/infrastructure/chat_reaction/ChatReactionRepositoryImpl.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/infrastructure/chat_reaction/ChatReactionRepositoryImpl.java
@@ -55,8 +55,8 @@ public class ChatReactionRepositoryImpl implements ChatReactionRepository {
     @Override
     public Map<Long, Map<ChatReactionRequest.ReactionType, Integer>> findReactionCountsByChatIdsIn(List<Long> chatIds){
         if (chatIds == null || chatIds.isEmpty()) {
-            log.error("@@ chatIds가 null or empty 입니다.");
-            log.error("@@ chatIds = {}", chatIds);
+            log.warn("@@ chatIds가 null or empty 입니다.");
+            log.warn("@@ chatIds = {}", chatIds);
             return Collections.emptyMap();
         }
 

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/presentation/controller/ChatControllerV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/presentation/controller/ChatControllerV1.java
@@ -127,7 +127,7 @@ public class ChatControllerV1 {
 						throw new CustomException(ErrorCode.NOT_FOUND_USER, "userId 가 null 입니다.");
 					}
 				}
-		return chatService.getChatMessages(roomId, cursor, userId);
+		return chatService.getChatMessagesV2(roomId, cursor, userId);
 	}
 
 	@Operation(

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/presentation/dto/chat/ReactionCountDto.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/presentation/dto/chat/ReactionCountDto.java
@@ -1,0 +1,13 @@
+package com.debateseason_backend_v1.domain.chat.presentation.dto.chat;
+
+import com.debateseason_backend_v1.domain.chat.presentation.dto.chat.request.ChatReactionRequest;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReactionCountDto {
+    private final Long chatId;
+    private final ChatReactionRequest.ReactionType reactionType;
+    private final Long count;
+}


### PR DESCRIPTION
기존에 메시지 조회시 84개의 쿼리가 실행되던 문제를
배치쿼리로 6개의 쿼리가 실행될수있도록 최적화

## 📌 변경 사항
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
채팅 메시지 조회 API(GET /api/v1/chat/rooms/{roomId}/messages)에서 발생하던 심각한 N+1 문제를 해결했습니다.

기존에는 메시지 20개 조회 시 84개의 SQL 쿼리가 실행되었으나, 배치 쿼리(Batch Query)를 도입하여 동일 조건에서 6개의 쿼리만 실행되도록 최적화했습니다. (쿼리 수 93% 감소)

이를 통해 K6 부하 테스트에서 p95 응답 시간을 3.9초에서 500ms 미만으로 개선하고, 최대 65%에 달하던 요청 실패율을 0%로 안정화하는 것을 목표로 합니다.   

[해당 문제에 대해서 정리한 글입니다.](https://kingbini.tistory.com/72)


## 🔍 관련 이슈
<!-- 관련된 이슈 번호가 있다면 #번호 형식으로 기입해주세요 -->
- Closes #

## ✨ 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
1. 배치 조회를 위한 DTO 및 Repository 메서드 추가
- ReactionCountDto: GROUP BY 쿼리 결과를 타입 안전하게 받기 위한 DTO를 추가했습니다.
- ChatReactionRepository: IN 절을 사용하는 배치 조회용 메서드 findReactionCountsByChatIdsIn, findUserReactionsByChatIdsIn를 추가했습니다.
- JPQL의 생성자 표현식(Constructor Expression)을 사용하여 DB 조회 결과를 즉시 DTO로 매핑하도록 구현했습니다.  

2. 서비스 로직 최적화
- ChatServiceV1.getChatMessages: 기존 Stream.map 내부에서 발생하던 반복적인 Repository 호출을 제거했습니다.
- 메시지 목록을 먼저 조회한 후, chatId 리스트를 추출하여 루프 외부에서 단 두 번의 배치 쿼리로 모든 반응 정보를 가져오도록 로직을 변경했습니다.
 
3. 응답 DTO 팩토리 메서드 최적화
- ChatMessageResponse: 배치 조회된 Map 데이터를 파라미터로 받는 새로운 정적 팩토리 메서드 fromOptimized를 추가했습니다.
- 이 메서드는 DB 접근 없이 메모리 상에서 O(1) 시간 복잡도로 반응 정보를 매핑합니다.

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 단위 테스트 및 로컬 API 호출 테스트를 완료하셨나요? (쿼리 실행 수 6개 확인 완료)

## 📝 리뷰어 참고 사항
<!-- PR을 리뷰할 때 알아야 할 내용을 적어주세요 -->
N+1 문제 발생 원인
기존 코드는 ChatMessageResponse를 생성하는 과정에서, 각 ChatEntity마다 ChatReactionRepository를 4번씩 호출하여 발생했습니다.
- countByChatIdAndReactionType (LOGIC)
- countByChatIdAndReactionType (ATTITUDE)
- findByChatIdAndUserIdAndReactionType (LOGIC)
- findByChatIdAndUserIdAndReactionType (ATTITUDE)

개선 후 쿼리 실행 흐름
1. ChatRoom 조회 (1개) (방어로직 입니다)
2. Chat 목록 조회 (1개) 
3. ChatReaction 반응 수 배치 조회 (1개)
4. ChatReaction 사용자 반응 여부 배치 조회 (1개)
5. Report 목록 조회 (1개)
6. Chat 전체 수 조회 (1개)

위의 쿼리 총 6개의 쿼리가 실행되는것을 테스트를 통해 확인했습니다.
이전에 채팅 메시지 API를 한번 호출하는데 84개의 쿼리가 실행되었는데 이번 개선 작업을 통해서 6개의 쿼리가 실행되도록 개선했습니다.
<img width="912" height="104" alt="스크린샷 2025-08-05 오후 3 02 39" src="https://github.com/user-attachments/assets/7e0f52c4-02fa-4f5b-87d2-9cda172761b4" />

