### PR TITLE
feat : Optional Auth 아키텍처 + Rate Limiting 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,9 @@ dependencies {
 
     // Firebase Admin SDK for FCM
     implementation 'com.google.firebase:firebase-admin:9.2.0'
+
+    // Rate Limiting
+    implementation 'com.bucket4j:bucket4j-core:8.10.1'
 }
 
 jacoco {

--- a/docs/backend-vive-edit-history.md
+++ b/docs/backend-vive-edit-history.md
@@ -1,0 +1,402 @@
+# Backend 편집 이력
+
+## 2026-02-27: Optional Authentication 아키텍처 구현
+
+### 목적
+토론철 서비스를 웹(Next.js)에 확장하기 위해, 기존 모든 API가 JWT 필수인 구조를 **3-Tier 인증 레벨**(Public / Optional Auth / Required Auth)로 전환.
+비로그인 사용자가 이슈/토론을 열람할 수 있게 하면서, 채팅/투표 등 참여 시에만 로그인을 요구한다.
+기존 모바일 앱은 항상 토큰을 보내므로 영향 없음.
+
+### 인증 흐름 변경
+
+```
+[변경 전]
+Public URL? → Yes → skip (인증 없이 통과)
+             → No  → 토큰 검증 (없으면 401)
+
+[변경 후]
+Public URL?     → Yes → skip (인증 없이 통과)
+                → No  → Optional Auth URL? → Yes → 토큰 있으면 파싱, 없으면 anonymous 통과
+                                            → No  → 토큰 검증 (없으면 401)
+```
+
+### 변경 파일 목록 (8개)
+
+| # | 파일 | 변경 유형 |
+|---|------|----------|
+| 1 | `WebSecurityConfig.java` | Security 설정 |
+| 2 | `SecurityPathMatcher.java` | URL 매칭 |
+| 3 | `JwtAuthenticationFilter.java` | 필터 분기 |
+| 4 | `IssueControllerV1.java` | 컨트롤러 null-safe |
+| 5 | `IssueServiceV1.java` | 서비스 null-safe |
+| 6 | `ChatRoomControllerV1.java` | 컨트롤러 null-safe |
+| 7 | `ChatRoomServiceV1.java` | 서비스 null-safe |
+| 8 | `UserControllerV1.java` | dead code 제거 |
+
+---
+
+### 1. WebSecurityConfig.java
+
+**경로:** `src/main/java/com/debateseason_backend_v1/config/WebSecurityConfig.java`
+
+**변경 내용:**
+- `OPTIONAL_AUTH_URLS` 상수 배열 추가 (6개 URL 패턴)
+- `filterChain()` 내 `authorizeHttpRequests`에 `.requestMatchers(OPTIONAL_AUTH_URLS).permitAll()` 추가
+
+**추가된 코드:**
+```java
+public static final String[] OPTIONAL_AUTH_URLS = {
+    "/api/v1/issue",
+    "/api/v1/issue-map",
+    "/api/v1/home/recommend",
+    "/api/v1/home/media",
+    "/api/v1/room",
+    "/api/v1/users/home"
+};
+```
+
+```java
+.authorizeHttpRequests(auth -> auth
+    .requestMatchers(PUBLIC_URLS).permitAll()
+    .requestMatchers(OPTIONAL_AUTH_URLS).permitAll()   // 신규
+    .anyRequest().authenticated()
+)
+```
+
+**설계 의도:**
+- Spring Security 레벨에서 Optional Auth URL들을 `permitAll()`로 설정하여 SecurityFilterChain이 401을 내지 않도록 함
+- 실제 인증 로직은 `JwtAuthenticationFilter`에서 처리
+
+---
+
+### 2. SecurityPathMatcher.java
+
+**경로:** `src/main/java/com/debateseason_backend_v1/security/component/SecurityPathMatcher.java`
+
+**변경 내용:**
+- `isOptionalAuthUrl(String requestURI, String method)` 메서드 추가
+- 기존 `isPublicUrl()` 내 context path 제거 로직을 `removeContextPath()` private 메서드로 추출하여 재사용
+- import문을 `WebSecurityConfig.*` 와일드카드에서 `OPTIONAL_AUTH_URLS`, `PUBLIC_URLS` 명시적 import로 변경
+
+**추가된 메서드:**
+```java
+public boolean isOptionalAuthUrl(String requestURI, String method) {
+    String path = removeContextPath(requestURI);
+
+    // /api/v1/room은 GET만 Optional, POST는 Required Auth
+    if (pathMatcher.match("/api/v1/room", path)) {
+        return "GET".equalsIgnoreCase(method);
+    }
+
+    return Arrays.stream(OPTIONAL_AUTH_URLS)
+        .anyMatch(pattern -> pathMatcher.match(pattern, path));
+}
+
+private String removeContextPath(String requestURI) {
+    if (!contextPath.isEmpty() && requestURI.startsWith(contextPath)) {
+        return requestURI.substring(contextPath.length());
+    }
+    return requestURI;
+}
+```
+
+**리팩터링된 기존 메서드:**
+```java
+// Before: context path 제거 로직이 isPublicUrl() 안에 인라인
+// After: removeContextPath() 호출로 단순화
+public boolean isPublicUrl(String requestURI) {
+    String path = removeContextPath(requestURI);
+    return Arrays.stream(PUBLIC_URLS)
+        .anyMatch(pattern -> pathMatcher.match(pattern, path));
+}
+```
+
+**설계 의도:**
+- `/api/v1/room`은 GET(채팅방 조회)만 Optional Auth, POST(채팅방 생성)는 Required Auth이므로 HTTP Method도 검사
+- 나머지 Optional Auth URL은 method 무관하게 Optional Auth 적용
+
+---
+
+### 3. JwtAuthenticationFilter.java
+
+**경로:** `src/main/java/com/debateseason_backend_v1/security/jwt/JwtAuthenticationFilter.java`
+
+**변경 내용:**
+- `doFilterInternal()` 메서드에 Optional Auth URL 분기 추가 (Public URL 체크 직후, Required Auth 체크 직전)
+- `tryOptionalAuthentication(HttpServletRequest request)` private 메서드 추가
+
+**doFilterInternal() 내 추가된 분기 (L48-53):**
+```java
+// Optional Auth: 토큰 있으면 파싱, 없으면 anonymous로 통과
+if (securityPathMatcher.isOptionalAuthUrl(requestURI, request.getMethod())) {
+    tryOptionalAuthentication(request);
+    filterChain.doFilter(request, response);
+    return;
+}
+```
+
+**추가된 메서드 (L130-144):**
+```java
+private void tryOptionalAuthentication(HttpServletRequest request) {
+    String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+    if (!containsValidHeader(authorizationHeader)) {
+        return;  // 토큰 없으면 anonymous로 통과
+    }
+    String token = removeBearerPrefix(authorizationHeader);
+    if (token == null) {
+        return;  // 형식 잘못되어도 anonymous로 통과
+    }
+    try {
+        authenticateWithAccessToken(token, request.getRequestURI());
+    } catch (Exception e) {
+        // 만료/잘못된 토큰이어도 에러를 내지 않고 anonymous로 통과
+        log.debug("Optional auth failed, continuing as anonymous: {}", e.getMessage());
+    }
+}
+```
+
+**설계 의도:**
+- 토큰이 있으면 기존 `authenticateWithAccessToken()`으로 SecurityContext에 인증 정보 설정
+- 토큰이 없거나 유효하지 않으면 에러 없이 anonymous로 통과 → 컨트롤러에서 `@AuthenticationPrincipal`이 null이 됨
+- 기존 Required Auth 흐름은 전혀 변경하지 않음
+
+---
+
+### 4. IssueControllerV1.java
+
+**경로:** `src/main/java/com/debateseason_backend_v1/domain/issue/presentation/controller/IssueControllerV1.java`
+
+**변경 내용:**
+- `getIssue()` (GET /api/v1/issue): principal null-safe 처리
+- `getRecommend()` (GET /api/v1/home/recommend): principal null-safe 처리
+
+**변경 전 (getIssue, L51):**
+```java
+Long userId = principal.getUserId();  // principal이 null이면 NPE
+```
+
+**변경 후 (getIssue, L51):**
+```java
+Long userId = principal != null ? principal.getUserId() : null;
+```
+
+**변경 전 (getRecommend, L91):**
+```java
+Long userId = principal.getUserId();  // principal이 null이면 NPE
+```
+
+**변경 후 (getRecommend, L91):**
+```java
+Long userId = principal != null ? principal.getUserId() : null;
+```
+
+**변경하지 않은 메서드:**
+- `indexPage()` (GET /home/refresh): Required Auth 유지 (반드시 userId 필요)
+- `bookMarkIssue()` (POST /bookmark): Required Auth 유지 (사용자 행위)
+
+---
+
+### 5. IssueServiceV1.java
+
+**경로:** `src/main/java/com/debateseason_backend_v1/domain/issue/application/service/IssueServiceV1.java`
+
+**변경 내용:**
+`fetchV2(Long issueId, Long userId, Long ChatRoomId)` 메서드 내 userId가 null인 경우 분기 처리
+
+**변경된 로직 (3개 블록):**
+
+**(1) 북마크 상태 조회 (L92-100):**
+```java
+// 변경 전: 무조건 userIssueRepository.findByIssueIdAndUserId(issueId, userId) 호출
+// 변경 후: userId가 null이면 조회 스킵, 기본값 "no" 유지
+String bookMarkState = "no";
+if (userId != null) {
+    List<Object[]> object = userIssueRepository.findByIssueIdAndUserId(issueId, userId);
+    if (!object.isEmpty()) {
+        Object[] object2 = object.get(0);
+        bookMarkState = (String)object2[0];
+    }
+}
+```
+
+**(2) 프로필 조회 & 커뮤니티 기록 (L110-126):**
+```java
+// 변경 전: profileRepository.findByUserId(userId) → userId가 null이면 NPE 핵심 원인
+// 변경 후: userId가 null이면 프로필 조회/커뮤니티 기록 전체 스킵
+if (userId != null) {
+    ProfileEntity profile = profileRepository.findByUserId(userId).orElseThrow(...);
+    CommunityType communityType = profile.getCommunityType();
+    if (communityType == null) {
+        throw new CustomException(ErrorCode.NOT_FOUND_COMMUNITY);
+    }
+    UserDTO userDTO = new UserDTO();
+    userDTO.setCommunity(communityType.getName());
+    userDTO.setId(userId);
+    communityMananger.record(userDTO, issueId);
+}
+// getSortedCommunity()는 항상 호출 (기존 데이터 반환)
+LinkedHashMap<String, Integer> sortedMap = communityMananger.getSortedCommunity(issueId);
+```
+
+**(3) 사용자 투표 상태 조회 (L140-144):**
+```java
+// 변경 전: 무조건 userChatRoomRepository.findUserChatRoomOpinions(userId, chatRoomIds) 호출
+// 변경 후: 로그인 사용자만 개인 투표 상태 조회
+if (userId != null) {
+    List<Object[]> opinions = userChatRoomRepository.findUserChatRoomOpinions(userId, chatRoomIds);
+    markUserOpinion(opinions, chatRooms);
+}
+```
+
+**비로그인 사용자 응답 결과:**
+- `bookMarkState`: "no" (기본값)
+- `map` (커뮤니티 맵): 기존 데이터만 (방문 기록 추가 없음)
+- `chatRoomMap`의 각 채팅방 `opinion`: NEUTRAL (기본값, markUserOpinion 미호출)
+
+---
+
+### 6. ChatRoomControllerV1.java
+
+**경로:** `src/main/java/com/debateseason_backend_v1/domain/chatroom/controller/ChatRoomControllerV1.java`
+
+**변경 내용:**
+- `fetch()` (GET /api/v1/room): principal null-safe 처리
+
+**변경 전 (L64):**
+```java
+Long userId = principal.getUserId();  // principal이 null이면 NPE
+```
+
+**변경 후 (L64):**
+```java
+Long userId = principal != null ? principal.getUserId() : null;
+```
+
+**변경하지 않은 메서드:**
+- `save()` (POST /room): `@AuthenticationPrincipal` 미사용 — 변경 불필요
+- `vote()` (POST /room/vote): Required Auth 유지 (사용자 행위)
+
+---
+
+### 7. ChatRoomServiceV1.java
+
+**경로:** `src/main/java/com/debateseason_backend_v1/domain/chatroom/service/ChatRoomServiceV1.java`
+
+**변경 내용 (2개 메서드):**
+
+**(1) fetch() — 채팅방 단건 조회 (L140-146):**
+```java
+// 변경 전: userId가 null이면 userChatRoomRepository.findByUserIdAndChatRoomId()에서 문제 발생 가능
+String opinion = Optional.ofNullable(userChatRoomRepository.findByUserIdAndChatRoomId(userId, chatRoomId))
+    .map(UserChatRoom::getOpinion)
+    .orElse(Opinion.NEUTRAL.name());
+
+// 변경 후: userId가 null이면 조회 스킵, NEUTRAL 기본값 유지
+String opinion = Opinion.NEUTRAL.name();
+if (userId != null) {
+    opinion = Optional.ofNullable(userChatRoomRepository.findByUserIdAndChatRoomId(userId, chatRoomId))
+        .map(UserChatRoom::getOpinion)
+        .orElse(Opinion.NEUTRAL.name());
+}
+```
+
+**(2) findVotedChatRoom() — 투표한 채팅방 목록 (L341-359):**
+```java
+// 추가된 early return 블록: userId가 null이면 공개 데이터만 반환
+if (userId == null) {
+    List<Top5BestChatRoom> top5BestChatRooms = chatRoomProcessor.getTop5ActiveRooms();
+    List<IssueBriefResponse> top5BestIssueRooms = issueManager.findTop5BestIssueRooms();
+
+    UserVotedChatRoom userVotedChatRoom = UserVotedChatRoom.builder()
+        .breakingNews(breakingNews)
+        .chatRoomResponse(List.of())       // 빈 리스트 (투표 기록 없음)
+        .top5BestChatRooms(top5BestChatRooms)
+        .top5BestIssueRooms(top5BestIssueRooms)
+        .build();
+
+    return ApiResult.<UserVotedChatRoom>builder()
+        .status(200)
+        .code(ErrorCode.SUCCESS)
+        .message("채팅방을 불러왔습니다.")
+        .data(userVotedChatRoom)
+        .build();
+}
+```
+
+**비로그인 사용자 응답 결과:**
+- `fetch()`: opinion = "NEUTRAL", 나머지 채팅방 데이터(찬성/반대 수, 팀 스코어 등)는 정상 반환
+- `findVotedChatRoom()`: breakingNews + top5BestChatRooms + top5BestIssueRooms는 반환, chatRoomResponse는 빈 리스트
+
+---
+
+### 8. UserControllerV1.java
+
+**경로:** `src/main/java/com/debateseason_backend_v1/domain/user/presentation/controller/UserControllerV1.java`
+
+**변경 내용:**
+- `indexPage()` (GET /api/v1/users/home): 사용하지 않는 `userId` 추출 코드 제거
+
+**변경 전 (L70-80):**
+```java
+@GetMapping("/home")
+public ApiResult<List<IssueBriefResponse>> indexPage(
+    //@RequestParam(name = "page", required = false) Long page,
+    @AuthenticationPrincipal CustomUserDetails principal
+) {
+    Long userId = principal.getUserId();  // 추출하지만 사용 안 함 → dead code
+    //return chatRoomServiceV1.findVotedChatRoom(userId,page);
+    return issueServiceV1.fetchV1();
+}
+```
+
+**변경 후 (L69-74):**
+```java
+@GetMapping("/home")
+public ApiResult<List<IssueBriefResponse>> indexPage(
+    @AuthenticationPrincipal CustomUserDetails principal
+) {
+    return issueServiceV1.fetchV1();  // userId 미사용이므로 추출 불필요
+}
+```
+
+**설계 의도:**
+- `principal` 파라미터는 유지 (향후 개인화 용도 + interface 호환성)
+- `userId` 추출 코드만 제거하여 principal이 null이어도 안전
+
+---
+
+### 변경하지 않은 엔드포인트
+
+| 엔드포인트 | 이유 |
+|-----------|------|
+| `GET /api/v1/issue-map` | `@AuthenticationPrincipal` 미사용 — Security 설정만 열면 됨 |
+| `GET /api/v1/home/media` | `@AuthenticationPrincipal` 미사용 — Security 설정만 열면 됨 |
+| `GET /api/v1/home/refresh` | "내가 투표한 채팅방" → 반드시 userId 필요 → Required Auth 유지 |
+| `POST /api/v1/bookmark` | 사용자 행위 → Required Auth 유지 |
+| `POST /api/v1/room/vote` | 사용자 행위 → Required Auth 유지 |
+| `POST /api/v1/room` | `@AuthenticationPrincipal` 미사용 — 변경 불필요 |
+
+---
+
+### 빌드 결과
+
+- **컴파일**: `./gradlew build -x test` → BUILD SUCCESSFUL
+- **테스트**: `./gradlew test` → 60개 중 58개 통과, 2개 실패
+  - 실패한 테스트: `ChatApiTest.채팅메시지_조회_성공()`, `ChatWebSocketTest.채팅메시지_전송_및_수신_성공()`
+  - 이번 변경과 무관한 기존 실패 (chat 도메인 통합 테스트)
+
+### 엔드포인트별 인증 레벨 최종 정리
+
+| 인증 레벨 | 엔드포인트 | 비로그인 접근 |
+|-----------|-----------|-------------|
+| **Public** | `/api/v1/users/login`, `/api/v1/auth/reissue`, `/api/v1/app/**` 등 | O |
+| **Optional Auth** | `GET /api/v1/issue` | O (개인화 데이터 제외) |
+| **Optional Auth** | `GET /api/v1/issue-map` | O |
+| **Optional Auth** | `GET /api/v1/home/recommend` | O (투표 채팅방 빈 리스트) |
+| **Optional Auth** | `GET /api/v1/home/media` | O |
+| **Optional Auth** | `GET /api/v1/room` | O (opinion=NEUTRAL) |
+| **Optional Auth** | `GET /api/v1/users/home` | O |
+| **Required Auth** | `GET /api/v1/home/refresh` | X (401) |
+| **Required Auth** | `POST /api/v1/bookmark` | X (401) |
+| **Required Auth** | `POST /api/v1/room/vote` | X (401) |
+| **Required Auth** | `POST /api/v1/room` | X (401) |

--- a/docs/backend-vive-edit-history.md
+++ b/docs/backend-vive-edit-history.md
@@ -400,3 +400,290 @@ public ApiResult<List<IssueBriefResponse>> indexPage(
 | **Required Auth** | `POST /api/v1/bookmark` | X (401) |
 | **Required Auth** | `POST /api/v1/room/vote` | X (401) |
 | **Required Auth** | `POST /api/v1/room` | X (401) |
+
+---
+
+## 2026-03-01: Rate Limiting 구현
+
+### 목적
+AWS Lightsail 단일 인스턴스 환경에서 API 남용 방지를 위한 Rate Limiting 적용.
+Bucket4j 기반 in-memory Token Bucket 알고리즘으로 비로그인 IP당 100 req/min, 로그인 userId당 300 req/min 제한.
+
+### Rate Limiting 흐름
+
+```
+[필터 체인 순서]
+JwtAuthenticationFilter → RateLimitFilter → AuthorizationFilter
+
+[RateLimitFilter 내부 흐름]
+제외 URL? (/swagger-ui/**, /actuator/**, /ws-stomp/**)
+  → Yes → skip (Rate Limit 미적용)
+  → No  → SecurityContext에 인증 정보 있음?
+            → Yes → "user:{userId}" 키로 300 req/min 버킷 적용
+            → No  → "ip:{clientIp}" 키로 100 req/min 버킷 적용
+                     → 토큰 소비 성공? → Yes → 다음 필터로 진행
+                                        → No  → 429 + Retry-After 헤더 + JSON 에러 응답
+```
+
+### 의사결정
+
+**1. JwtAuthenticationFilter 뒤에 배치하는 이유**
+- `SecurityContext`에 인증 정보가 세팅된 후여야 로그인/비로그인을 구분 가능
+- JwtAuthenticationFilter가 먼저 실행되어 Optional Auth URL에서도 토큰이 있으면 인증 정보가 세팅됨
+- 인증된 사용자는 userId 기반 버킷, 비인증 사용자는 IP 기반 버킷으로 분리
+
+**2. Bucket4j in-memory 선택 이유**
+- AWS Lightsail 단일 인스턴스 환경 → Redis 등 외부 저장소 불필요
+- `ConcurrentHashMap<String, BucketEntry>` + `ScheduledExecutorService`로 단순하게 구현
+- 다중 인스턴스 확장 시 Redis 기반으로 전환 가능 (Bucket4j-redis 모듈 존재)
+
+**3. Caffeine 미사용 이유**
+- 의존성 최소화: Caffeine 추가 없이 `ScheduledExecutorService`로 5분마다 만료 엔트리(10분 미접근) 정리
+- `BucketEntry` 내부 클래스로 `lastAccessTime`을 `volatile`로 관리하여 thread-safe 보장
+
+**4. 설정값 외부화 (`@Value` + YAML)**
+- `RateLimitFilter`는 `new`로 직접 인스턴스화 (Spring 관리 Bean 아님) → filter 내부에서 `@Value` 사용 불가
+- `WebSecurityConfig`에서 `@Value`로 주입받아 생성자 파라미터로 전달
+- `application.yml`과 `application-prod.yml`에 분리하여 운영 모니터링 후 독립 조정 가능
+
+**5. IP 추출 시 `X-Forwarded-For` 우선 사용**
+- Lightsail 로드밸런서/리버스 프록시 뒤에서 실제 클라이언트 IP를 얻기 위함
+- `X-Forwarded-For` 헤더의 첫 번째 값(원본 클라이언트 IP)을 사용
+
+**6. 에러 응답 패턴 통일**
+- `JwtAuthenticationErrorHandler.writeErrorResponse()`와 동일한 패턴으로 429 응답 작성
+- `ObjectMapper` → `ErrorResponse` JSON 직렬화 → `response.setStatus()`, `setContentType()`, `setCharacterEncoding()`, `getWriter().write()`
+
+### 변경 파일 목록 (5개 수정 + 1개 신규)
+
+| # | 파일 | 변경 유형 |
+|---|------|----------|
+| 1 | `build.gradle` | 의존성 추가 |
+| 2 | `ErrorCode.java` | 에러 코드 추가 |
+| 3 | `RateLimitFilter.java` | **신규 생성** |
+| 4 | `WebSecurityConfig.java` | 필터 등록 + 설정 주입 |
+| 5 | `application.yml` | 설정값 추가 |
+| 6 | `application-prod.yml` | 설정값 추가 |
+
+---
+
+### 1. build.gradle
+
+**경로:** `build.gradle`
+
+**변경 내용:**
+- `com.bucket4j:bucket4j-core:8.10.1` 의존성 추가
+
+**추가된 코드:**
+```gradle
+// Rate Limiting
+implementation 'com.bucket4j:bucket4j-core:8.10.1'
+```
+
+---
+
+### 2. ErrorCode.java
+
+**경로:** `src/main/java/com/debateseason_backend_v1/common/exception/ErrorCode.java`
+
+**변경 내용:**
+- 8000번대 Rate Limiting 에러 코드 추가 (기존: 7000번대 동시성)
+
+**추가된 코드:**
+```java
+// 8000번대: Rate Limiting 에러
+RATE_LIMIT_EXCEEDED(8000, HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
+```
+
+---
+
+### 3. RateLimitFilter.java (신규)
+
+**경로:** `src/main/java/com/debateseason_backend_v1/security/filter/RateLimitFilter.java`
+
+**설계 패턴:**
+- `OncePerRequestFilter` 확장 (JwtAuthenticationFilter와 동일 패턴)
+- Spring Bean이 아닌 직접 인스턴스화 → 생성자로 의존성 주입
+
+**핵심 구조:**
+
+**(1) 버킷 키 결정 (L88-99):**
+```java
+Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+if (isAuthenticated(authentication)) {
+    CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+    bucketKey = "user:" + userDetails.getUserId();
+    rateLimit = authenticatedRateLimit;
+} else {
+    bucketKey = "ip:" + resolveClientIp(request);
+    rateLimit = anonymousRateLimit;
+}
+```
+- `isAuthenticated()`: `authentication != null && isAuthenticated() && principal instanceof CustomUserDetails`로 3중 체크
+- 로그인 사용자 → `"user:{userId}"`, 비로그인 → `"ip:{clientIp}"`
+
+**(2) Token Bucket 소비 (L101-113):**
+```java
+BucketEntry entry = buckets.computeIfAbsent(bucketKey, k -> new BucketEntry(createBucket(rateLimit)));
+entry.updateLastAccess();
+
+ConsumptionProbe probe = entry.getBucket().tryConsumeAndReturnRemaining(1);
+
+if (!probe.isConsumed()) {
+    long retryAfterSeconds = TimeUnit.NANOSECONDS.toSeconds(probe.getNanosToWaitForRefill()) + 1;
+    log.warn("Rate limit exceeded for key: {}, retry after: {}s", bucketKey, retryAfterSeconds);
+    response.setHeader("Retry-After", String.valueOf(retryAfterSeconds));
+    writeErrorResponse(response);
+    return;
+}
+```
+- `computeIfAbsent`로 키별 버킷 lazy 생성
+- `tryConsumeAndReturnRemaining(1)`로 토큰 1개 소비 시도
+- 초과 시 `Retry-After` 헤더에 대기 시간(초) 포함, WARN 로깅
+
+**(3) Bucket4j 8.10+ API 사용 (L142-146):**
+```java
+private Bucket createBucket(long capacity) {
+    return Bucket.builder()
+        .addLimit(limit -> limit.capacity(capacity).refillGreedy(capacity, Duration.ofMinutes(1)))
+        .build();
+}
+```
+- deprecated된 `Bandwidth.simple()` 대신 lambda builder API 사용
+- `refillGreedy`: 1분마다 capacity만큼 한번에 리필 (greedy 전략)
+
+**(4) 만료 엔트리 정리 (L159-175):**
+```java
+private void cleanupExpiredEntries() {
+    long now = System.currentTimeMillis();
+    var iterator = buckets.entrySet().iterator();
+    while (iterator.hasNext()) {
+        var entry = iterator.next();
+        if (now - entry.getValue().getLastAccessTime() > ENTRY_EXPIRATION_MILLIS) {
+            iterator.remove();
+        }
+    }
+}
+```
+- `ScheduledExecutorService` daemon 스레드가 5분 간격으로 실행
+- 10분 미접근 엔트리 제거 → 메모리 누수 방지
+
+**(5) BucketEntry 내부 클래스 (L177-197):**
+```java
+private static class BucketEntry {
+    private final Bucket bucket;
+    private volatile long lastAccessTime;  // volatile: 멀티스레드 가시성 보장
+    // ...
+}
+```
+
+**(6) 제외 URL (L34-38, L124-132):**
+```java
+private static final String[] EXCLUDED_PATHS = {
+    "/swagger-ui/**", "/actuator/**", "/ws-stomp/**"
+};
+```
+- `AntPathMatcher`로 패턴 매칭 (SecurityPathMatcher와 동일 방식)
+- Swagger, Actuator, WebSocket은 Rate Limiting 미적용
+
+---
+
+### 4. WebSecurityConfig.java
+
+**경로:** `src/main/java/com/debateseason_backend_v1/config/WebSecurityConfig.java`
+
+**변경 내용:**
+- `ObjectMapper` 의존성 추가 (기존 `@RequiredArgsConstructor`에 final 필드로 추가)
+- `@Value`로 rate-limit 설정값 주입
+- `RateLimitFilter` 인스턴스 생성 및 `JwtAuthenticationFilter` 뒤에 등록
+
+**추가된 필드:**
+```java
+private final ObjectMapper objectMapper;
+
+@Value("${rate-limit.anonymous-requests-per-minute:100}")
+private long anonymousRateLimit;
+
+@Value("${rate-limit.authenticated-requests-per-minute:300}")
+private long authenticatedRateLimit;
+```
+
+**변경된 filterChain() 메서드:**
+```java
+// 변경 전: 인라인 생성
+.addFilterBefore(
+    new JwtAuthenticationFilter(jwtUtil, errorHandler, securityPathMatcher),
+    UsernamePasswordAuthenticationFilter.class
+)
+
+// 변경 후: 변수 추출 + RateLimitFilter 추가
+JwtAuthenticationFilter jwtFilter = new JwtAuthenticationFilter(jwtUtil, errorHandler, securityPathMatcher);
+RateLimitFilter rateLimitFilter = new RateLimitFilter(
+    securityPathMatcher, objectMapper, anonymousRateLimit, authenticatedRateLimit
+);
+
+// ...
+.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+.addFilterAfter(rateLimitFilter, JwtAuthenticationFilter.class)
+```
+
+**설계 의도:**
+- `addFilterAfter(rateLimitFilter, JwtAuthenticationFilter.class)`: JWT 인증이 먼저 실행된 후 Rate Limiting 적용
+- 최종 필터 순서: `JwtAuthenticationFilter` → `RateLimitFilter` → `UsernamePasswordAuthenticationFilter` (비활성)
+
+---
+
+### 5. application.yml
+
+**경로:** `src/main/resources/application.yml`
+
+**추가된 설정:**
+```yaml
+rate-limit:
+  anonymous-requests-per-minute: 100
+  authenticated-requests-per-minute: 300
+```
+
+---
+
+### 6. application-prod.yml
+
+**경로:** `src/main/resources/application-prod.yml`
+
+**추가된 설정:**
+```yaml
+rate-limit:
+  anonymous-requests-per-minute: 100
+  authenticated-requests-per-minute: 300
+```
+
+**설계 의도:**
+- 초기에는 동일값이지만, 운영 모니터링 후 독립 조정 가능하도록 분리
+
+---
+
+### 빌드 결과
+
+- **컴파일**: `./gradlew build -x test` → BUILD SUCCESSFUL (deprecation 경고 없음)
+- **테스트**: `./gradlew test` → 60개 중 58개 통과, 2개 실패
+  - 실패한 테스트: `ChatApiTest.채팅메시지_조회_성공()`, `ChatWebSocketTest.채팅메시지_전송_및_수신_성공()`
+  - 이번 변경과 무관한 기존 실패 (chat 도메인 통합 테스트)
+
+### Rate Limiting 적용 범위 정리
+
+| 대상 | Rate Limit | 버킷 키 |
+|------|-----------|---------|
+| 비로그인 사용자 | 100 req/min | `ip:{clientIp}` |
+| 로그인 사용자 | 300 req/min | `user:{userId}` |
+| Swagger / Actuator / WebSocket | 미적용 (제외) | — |
+
+### 429 응답 예시
+
+```json
+{
+  "status": 429,
+  "code": "RATE_LIMIT_EXCEEDED",
+  "message": "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."
+}
+```
+- `Retry-After` 헤더: 버킷 리필까지 남은 초(+1) 포함

--- a/docs/rate-limiting-plan.md
+++ b/docs/rate-limiting-plan.md
@@ -1,0 +1,188 @@
+# Rate Limiting 구현 계획
+
+## 1. 배경 및 목적
+
+Optional Authentication 아키텍처 도입으로 비인증 엔드포인트(Level 0, Level 1)가 늘어남에 따라, 봇/크롤러/악의적 트래픽 증가에 대비한 IP 및 사용자 기반 Rate Limiting이 필요하다.
+
+### 현재 인프라 환경
+
+- **서버**: AWS Lightsail 단일 인스턴스
+- **Spring Boot 3.3.5** / **Java 17** / **Gradle**
+- Rate Limiting 라이브러리 **미도입**
+- `ErrorCode`에 이미 `TOO_MANY_REQUESTS(429)` HTTP 상태 패턴 존재 (`JWKS_RATE_LIMIT_REACHED`)
+- 필터 체인: `JwtAuthenticationFilter` → `UsernamePasswordAuthenticationFilter`
+- Redis 등 외부 캐시 **미사용** (순수 Spring Boot + MariaDB 구조)
+
+### 인프라 특성에 따른 설계 방향
+
+- Lightsail 단일 인스턴스이므로 **in-memory Rate Limiting**이 가장 적합
+- ALB/WAF가 없으므로 **앱 레벨에서 직접 방어**해야 함
+- 로드 밸런서 없이 단일 JVM이므로 인스턴스 간 동기화 불필요
+
+---
+
+## 2. 라이브러리 선택: Bucket4j
+
+| 선택지 | 장점 | 단점 |
+|--------|------|------|
+| **Bucket4j** | Token Bucket 알고리즘, Spring 호환 우수, 버스트 허용 | 의존성 1개 추가 |
+| 직접 구현 (AtomicInteger) | 의존성 없음 | edge case 처리 직접 해야 함 |
+| Resilience4j | Circuit Breaker 중심, Rate Limit은 부가 기능 | 설정 복잡 |
+| Nginx 레벨 | 앱 코드 변경 없음 | 인증 상태별 분기 불가, Lightsail에서 별도 Nginx 구성 필요 |
+
+**Bucket4j 선택 이유**: Token Bucket 알고리즘이 검증되어 있고, 인증 상태별 분기가 쉬움. 의존성은 `bucket4j-core` 하나만 추가.
+
+> Caffeine Cache는 추가하지 않는다. 메모리 정리는 `ScheduledExecutorService`로 충분하며, 단일 인스턴스 환경에서 의존성을 최소화한다.
+
+---
+
+## 3. Rate Limit 정책
+
+비로그인은 엔드포인트 인증 레벨(Public/Optional Auth)과 무관하게 **IP당 단일 버킷**으로 통합 운영한다.
+동일 IP에서 `/api/v1/users/login`과 `/api/v1/issue`를 번갈아 호출해도 같은 버킷에서 차감된다.
+
+| 구분 | 식별 키 | 제한 | 근거 |
+|------|---------|------|------|
+| **비로그인** | IP | 100 req/min | 봇/크롤러/브루트포스 방어 |
+| **로그인** | userId | 300 req/min | 정상 사용자 여유 확보 |
+
+- 로그인 사용자는 `userId` 기반 → IP 공유 환경(회사/학교)에서 불이익 없음
+- 비로그인은 `IP` 기반 → 엔드포인트별 분리 시 오히려 총 허용량이 늘어나므로 통합
+
+---
+
+## 4. 아키텍처 설계
+
+### 필터 위치
+
+`RateLimitFilter`는 `JwtAuthenticationFilter` **뒤**에 위치시킨다.
+
+```
+요청 → JwtAuthenticationFilter → RateLimitFilter → Controller
+                                      ↓
+                               SecurityContext에 userId 있으면 → userId 버킷
+                               없으면 → IP 버킷
+                               초과 시 → 429 반환
+```
+
+**트레이드오프**:
+- JWT 파싱 **뒤**에 두면 `SecurityContext`에서 인증 정보를 바로 가져올 수 있어 구현이 단순
+- 대신 Rate Limit 초과 요청도 JWT 파싱을 거침
+- JWT 파싱은 마이크로초 단위의 가벼운 연산이므로, 현재 Lightsail 단일 인스턴스 규모에서 실질적 성능 영향 없음
+
+### 버킷 저장소
+
+```
+ConcurrentHashMap<String, Bucket>
+  key: "ip:192.168.1.1" 또는 "user:12345"
+  value: Bucket (토큰 버킷)
+```
+
+### 메모리 누수 방지
+
+`ConcurrentHashMap`에 IP/userId 키가 무한히 쌓이는 문제를 `ScheduledExecutorService`로 해결한다.
+
+- **주기**: 5분마다 실행
+- **정리 대상**: 마지막 요청 후 10분 경과한 버킷 제거
+- 별도 라이브러리(Caffeine) 없이 `ConcurrentHashMap` + 타임스탬프 기록으로 구현
+
+```java
+// 버킷과 마지막 접근 시간을 함께 관리
+ConcurrentHashMap<String, BucketEntry> buckets;
+
+record BucketEntry(Bucket bucket, long lastAccessedAt) {}
+
+// 5분마다 만료된 엔트리 정리
+scheduler.scheduleAtFixedRate(() -> {
+    long now = System.currentTimeMillis();
+    buckets.entrySet().removeIf(e -> now - e.getValue().lastAccessedAt() > EXPIRE_MILLIS);
+}, 5, 5, TimeUnit.MINUTES);
+```
+
+### IP 추출
+
+Lightsail은 직접 외부에 노출되거나 Lightsail 로드 밸런서 뒤에 위치할 수 있다.
+
+```java
+String ip = request.getHeader("X-Forwarded-For");
+if (ip == null || ip.isBlank()) {
+    ip = request.getRemoteAddr();
+} else {
+    ip = ip.split(",")[0].trim(); // 첫 번째 IP가 클라이언트
+}
+```
+
+> **주의**: Lightsail 로드 밸런서를 사용하지 않고 직접 노출된 경우, `X-Forwarded-For` 헤더를 클라이언트가 위조할 수 있다. 운영 환경에서 프록시 구성을 확인한 뒤 신뢰할 헤더를 결정해야 한다.
+
+---
+
+## 5. 429 응답 형식
+
+기존 `ErrorResponse` 패턴에 맞춤:
+
+```json
+{
+  "status": 429,
+  "code": "RATE_LIMIT_EXCEEDED",
+  "message": "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."
+}
+```
+
+- `Retry-After` 헤더를 포함하여 클라이언트가 재시도 시점을 알 수 있게 한다
+- 응답은 `JwtAuthenticationErrorHandler`와 동일한 `writeErrorResponse` 패턴을 따름
+
+---
+
+## 6. 모니터링 및 로깅
+
+Rate Limit 발동 시 로깅이 없으면 공격 탐지와 임계값 튜닝이 불가능하다.
+
+- Rate Limit **초과 시**: `WARN` 레벨 로깅 (IP/userId, 요청 URI)
+- 로그 예시: `Rate limit exceeded for ip:203.0.113.5, uri: /api/v1/issue`
+- 운영 중 임계값 조정이 필요하면 `application-prod.yml` 수정 후 재배포
+
+---
+
+## 7. 제외 대상
+
+| 대상 | 이유 |
+|------|------|
+| `/swagger-ui/**`, `/actuator/**` | 내부 개발/운영 도구 — prod에서 접근 제한 별도 처리 |
+| `/ws-stomp/**` | WebSocket은 HTTP 필터 경로와 별개, 필요 시 STOMP `ChannelInterceptor`에서 별도 처리 |
+| 특정 크롤러 (Googlebot 등) | `User-Agent` 기반 화이트리스트는 위조 가능 → IP 기반으로 통일 |
+
+---
+
+## 8. 구현 파일 목록
+
+| # | 파일 | 변경 유형 | 내용 |
+|---|------|----------|------|
+| 1 | `build.gradle` | 수정 | `bucket4j-core` 의존성 추가 |
+| 2 | `RateLimitFilter.java` | **신규** | `OncePerRequestFilter` 확장, 버킷 관리 및 429 응답 |
+| 3 | `WebSecurityConfig.java` | 수정 | 필터 체인에 `RateLimitFilter` 등록 |
+| 4 | `ErrorCode.java` | 수정 | `RATE_LIMIT_EXCEEDED` 에러 코드 추가 |
+| 5 | `application.yml` | 수정 | Rate Limit 기본 설정값 추가 |
+| 6 | `application-prod.yml` | 수정 | 운영 환경 Rate Limit 값 |
+
+> 기존 계획의 `RateLimitConfig.java`는 별도 파일 없이 `RateLimitFilter` 내에서 `@Value`로 설정값을 주입받아 단순화한다.
+
+---
+
+## 9. 구현 순서
+
+1. **의존성 추가** — `bucket4j-core` (build.gradle)
+2. **에러 코드 추가** — `ErrorCode.RATE_LIMIT_EXCEEDED`
+3. **필터 구현** — `RateLimitFilter` (핵심 로직 + 버킷 정리 스케줄러)
+4. **필터 등록** — `WebSecurityConfig`에 필터 추가
+5. **환경별 설정** — `application.yml`(기본값), `application-prod.yml`(운영값)
+6. **테스트** — 비로그인/로그인 각각 임계값 초과 시 429 확인
+
+---
+
+## 10. 향후 확장 시 고려사항
+
+현재 Lightsail 단일 인스턴스에서 다중 인스턴스로 확장할 경우:
+
+- **in-memory → Redis 전환** 필요 (`bucket4j-redis` 또는 `bucket4j-redisson`)
+- 인스턴스별 독립 버킷이면 Rate Limit이 인스턴스 수만큼 배로 허용됨
+- Redis 도입 시 `ConcurrentHashMap`을 Redis ProxyManager로 교체하면 `RateLimitFilter` 나머지 로직은 동일

--- a/src/main/java/com/debateseason_backend_v1/common/exception/ErrorCode.java
+++ b/src/main/java/com/debateseason_backend_v1/common/exception/ErrorCode.java
@@ -83,6 +83,9 @@ public enum ErrorCode implements CodeInterface {
 	// 7000번대: 동시성 관련 에러
 	CONCURRENT_REQUEST(7000, HttpStatus.CONFLICT, "요청 처리 중 충돌이 발생했습니다. 잠시 후 다시 시도해주세요."),
 
+	// 8000번대: Rate Limiting 에러
+	RATE_LIMIT_EXCEEDED(8000, HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
+
 	NOT_FOUND_REPORT(404, HttpStatus.NOT_FOUND, "NOT_FOUND"),
 
 	// API 요청 에러

--- a/src/main/java/com/debateseason_backend_v1/config/WebSecurityConfig.java
+++ b/src/main/java/com/debateseason_backend_v1/config/WebSecurityConfig.java
@@ -39,6 +39,15 @@ public class WebSecurityConfig {
 		"/api/v1/app/**"
 	};
 
+	public static final String[] OPTIONAL_AUTH_URLS = {
+		"/api/v1/issue",
+		"/api/v1/issue-map",
+		"/api/v1/home/recommend",
+		"/api/v1/home/media",
+		"/api/v1/room",
+		"/api/v1/users/home"
+	};
+
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
@@ -48,6 +57,7 @@ public class WebSecurityConfig {
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(PUBLIC_URLS).permitAll()
+				.requestMatchers(OPTIONAL_AUTH_URLS).permitAll()
 				.anyRequest().authenticated()
 			)
 			.addFilterBefore(

--- a/src/main/java/com/debateseason_backend_v1/config/WebSecurityConfig.java
+++ b/src/main/java/com/debateseason_backend_v1/config/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.debateseason_backend_v1.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -12,8 +13,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 import com.debateseason_backend_v1.security.component.SecurityPathMatcher;
 import com.debateseason_backend_v1.security.error.JwtAuthenticationErrorHandler;
+import com.debateseason_backend_v1.security.filter.RateLimitFilter;
 import com.debateseason_backend_v1.security.jwt.JwtAuthenticationFilter;
 import com.debateseason_backend_v1.security.jwt.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +28,13 @@ public class WebSecurityConfig {
 	private final JwtUtil jwtUtil;
 	private final JwtAuthenticationErrorHandler errorHandler;
 	private final SecurityPathMatcher securityPathMatcher;
+	private final ObjectMapper objectMapper;
+
+	@Value("${rate-limit.anonymous-requests-per-minute:100}")
+	private long anonymousRateLimit;
+
+	@Value("${rate-limit.authenticated-requests-per-minute:300}")
+	private long authenticatedRateLimit;
 
 	public static final String[] PUBLIC_URLS = {
 		"/swagger-ui/**",
@@ -51,6 +61,11 @@ public class WebSecurityConfig {
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
+		JwtAuthenticationFilter jwtFilter = new JwtAuthenticationFilter(jwtUtil, errorHandler, securityPathMatcher);
+		RateLimitFilter rateLimitFilter = new RateLimitFilter(
+			securityPathMatcher, objectMapper, anonymousRateLimit, authenticatedRateLimit
+		);
+
 		return http
 			.csrf(AbstractHttpConfigurer::disable)
 			.formLogin(AbstractHttpConfigurer::disable)
@@ -60,10 +75,8 @@ public class WebSecurityConfig {
 				.requestMatchers(OPTIONAL_AUTH_URLS).permitAll()
 				.anyRequest().authenticated()
 			)
-			.addFilterBefore(
-				new JwtAuthenticationFilter(jwtUtil, errorHandler, securityPathMatcher),
-				UsernamePasswordAuthenticationFilter.class
-			)
+			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+			.addFilterAfter(rateLimitFilter, JwtAuthenticationFilter.class)
 			.build();
 	}
 }

--- a/src/main/java/com/debateseason_backend_v1/domain/chatroom/controller/ChatRoomControllerV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chatroom/controller/ChatRoomControllerV1.java
@@ -61,7 +61,7 @@ public class ChatRoomControllerV1 implements ChatRoomControllerV1Docs {
 		@AuthenticationPrincipal CustomUserDetails principal) {
 		// type은 토론위키일 수도 있고, 하이라이트일 수도 있고, 아무것도 없을 수도 있다.
 
-		Long userId = principal.getUserId();
+		Long userId = principal != null ? principal.getUserId() : null;
 		return chatRoomServiceV1.fetch(userId,chatRoomId);
 	}
 

--- a/src/main/java/com/debateseason_backend_v1/domain/chatroom/service/ChatRoomServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chatroom/service/ChatRoomServiceV1.java
@@ -138,10 +138,12 @@ public class ChatRoomServiceV1 {
 		);
 
 		// 2. 내가 이 토론방에 투표한 의견을 가져온다. null이면 NEUTRAL을 유지한다.
-		String opinion = Optional.ofNullable(userChatRoomRepository.findByUserIdAndChatRoomId(userId,chatRoomId))
-			.map(UserChatRoom::getOpinion)
-			.orElse(Opinion.NEUTRAL.name())
-			;
+		String opinion = Opinion.NEUTRAL.name();
+		if (userId != null) {
+			opinion = Optional.ofNullable(userChatRoomRepository.findByUserIdAndChatRoomId(userId, chatRoomId))
+				.map(UserChatRoom::getOpinion)
+				.orElse(Opinion.NEUTRAL.name());
+		}
 
 		/* Legacy
 		// opinion의 기본값 = NEUTRAL
@@ -333,9 +335,28 @@ public class ChatRoomServiceV1 {
 	// 4. 내가 투표한 여러 채팅방 가져오기
 	public ApiResult<UserVotedChatRoom> findVotedChatRoom(Long userId,Long pageChatRoomId){
 
-
 		// 1. 속보 가져오기
 		List<BreakingNewsResponse> breakingNews = mediaManager.findTop10BreakingNews();
+
+		// 비로그인: 투표한 채팅방 조회 불가 → 공개 데이터만 반환
+		if (userId == null) {
+			List<Top5BestChatRoom> top5BestChatRooms = chatRoomProcessor.getTop5ActiveRooms();
+			List<IssueBriefResponse> top5BestIssueRooms = issueManager.findTop5BestIssueRooms();
+
+			UserVotedChatRoom userVotedChatRoom = UserVotedChatRoom.builder()
+				.breakingNews(breakingNews)
+				.chatRoomResponse(List.of())
+				.top5BestChatRooms(top5BestChatRooms)
+				.top5BestIssueRooms(top5BestIssueRooms)
+				.build();
+
+			return ApiResult.<UserVotedChatRoom>builder()
+				.status(200)
+				.code(ErrorCode.SUCCESS)
+				.message("채팅방을 불러왔습니다.")
+				.data(userVotedChatRoom)
+				.build();
+		}
 
 		// 1. 최상위 5개 채팅방 가져오기
 		List<Top5BestChatRoom> top5BestChatRooms = chatRoomProcessor.getTop5ActiveRooms();

--- a/src/main/java/com/debateseason_backend_v1/domain/issue/application/service/IssueServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/issue/application/service/IssueServiceV1.java
@@ -89,62 +89,61 @@ public class IssueServiceV1 {
 	@Transactional
 	public ApiResult<IssueDetailResponse> fetchV2(Long issueId, Long userId, Long ChatRoomId) {
 
-
-		List<Object[]> object = userIssueRepository.findByIssueIdAndUserId(issueId, userId);
-
+		// 북마크 상태 조회 (비로그인 시 기본값 "no")
 		String bookMarkState = "no";
-		// 이 부분은 사용자가 북마크를 했는지 확인하기 위한 부분. 첫 방문 항상 bookmarkState는 no
-		if (!object.isEmpty()) {
-			Object[] object2 = object.get(0);
-			bookMarkState = (String)object2[0];
+		if (userId != null) {
+			List<Object[]> object = userIssueRepository.findByIssueIdAndUserId(issueId, userId);
+			if (!object.isEmpty()) {
+				Object[] object2 = object.get(0);
+				bookMarkState = (String)object2[0];
+			}
 		}
 
-		//  이슈와 북마크 개수 가져오기 <- 1.수정 필요. Object[] 말고.
-		// issue_id, title, COUNT(ui.issue_id) AS bookmarks
+		//  이슈와 북마크 개수 가져오기
 		List<Object[]> fetchIssue = issueRepository.findSingleIssueWithBookmarks(issueId);
 		Object[] tmp = fetchIssue.get(0);
-		IssueMapper issueMapper = IssueMapper.builder() // DB 필드 값 -> DTO
+		IssueMapper issueMapper = IssueMapper.builder()
 			.title((String)tmp[1])
 			.bookMarks((long)tmp[2])
 			.build();
 
+		// 커뮤니티 맵 (비로그인 시 방문 기록 없이 기존 데이터만 반환)
+		if (userId != null) {
+			ProfileEntity profile = profileRepository.findByUserId(userId).orElseThrow(
+				() -> new CustomException(ErrorCode.NOT_FOUND_PROFILE)
+			);
 
-		ProfileEntity profile = profileRepository.findByUserId(userId).orElseThrow(
-			() -> new CustomException(ErrorCode.NOT_FOUND_PROFILE)
-		);
+			CommunityType communityType = profile.getCommunityType();
+			if (communityType == null) {
+				throw new CustomException(ErrorCode.NOT_FOUND_COMMUNITY);
+			}
 
-		CommunityType communityType = profile.getCommunityType();
-		if (communityType == null) {
-			throw new CustomException(ErrorCode.NOT_FOUND_COMMUNITY);
+			UserDTO userDTO = new UserDTO();
+			userDTO.setCommunity(communityType.getName());
+			userDTO.setId(userId);
+
+			communityMananger.record(userDTO, issueId);
 		}
 
-		// 2. 서버 세션에 user 방문 기록 저장하기. 이는 커뮤니티 사용자 수를 내림차순으로 보여주기 위함임. UserDTO 수정 요함.
-		UserDTO userDTO = new UserDTO();
-		userDTO.setCommunity(communityType.getName());
-		userDTO.setId(userId);
-
-		//CommunityRecords.record(userDTO, issueId);
-		communityMananger.record(userDTO,issueId);
-
-		//LinkedHashMap<String, Integer> sortedMap = CommunityRecords.getSortedCommunity(issueId); // LinkedHashMap을 써서 순서를 보장한다.
 		LinkedHashMap<String, Integer> sortedMap = communityMananger.getSortedCommunity(issueId);
 
 		//
-		List<Long> chatRoomIds = chatRoomPaginationManager.getChatRoomsByPage(issueId,ChatRoomId); // 순차적으로 chatRoomId로 페이지네이션
+		List<Long> chatRoomIds = chatRoomPaginationManager.getChatRoomsByPage(issueId, ChatRoomId);
 
 		// 4. 채팅방을 반환 (없으면 없는대로 반환을 한다)
 		long chats = 0L;
 		List<ResponseWithTimeAndOpinion> chatRooms = null;
 
 		if (!chatRoomIds.isEmpty()) {
+			chatRooms = chatRoomProcessor.getChatRoomWithOpinionCount(chatRoomIds);
 
-			// 수정
-			chatRooms = chatRoomProcessor.getChatRoomWithOpinionCount(chatRoomIds); // chatRoomIds에 해당하는 채팅방 관련 정보(제목, 본문)+ 찬성/반대 가져오기
-			List<Object[]> opinions = userChatRoomRepository.findUserChatRoomOpinions(userId, chatRoomIds); // 해당 채팅방에 사용자의 개인 의견 표시하기
-			markUserOpinion(opinions,chatRooms); // chatRooms에 Opinion을 덮어 씌운다.
+			// 로그인 사용자만 개인 투표 상태 조회
+			if (userId != null) {
+				List<Object[]> opinions = userChatRoomRepository.findUserChatRoomOpinions(userId, chatRoomIds);
+				markUserOpinion(opinions, chatRooms);
+			}
 
-			chats = issueRepository.countChatsTodayByIssueId(issueId); // 오늘 신규 대화 -> 수정
-
+			chats = issueRepository.countChatsTodayByIssueId(issueId);
 		}
 
 		IssueDetailResponse issueDetailResponse = IssueDetailResponse.builder()

--- a/src/main/java/com/debateseason_backend_v1/domain/issue/presentation/controller/IssueControllerV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/issue/presentation/controller/IssueControllerV1.java
@@ -48,7 +48,7 @@ public class IssueControllerV1 implements IssueControllerV1Docs {
 		@RequestParam(name = "issue-id") Long issueId,
 		@AuthenticationPrincipal CustomUserDetails principal,
 		@RequestParam(name = "page",required = false)Long page) {
-		Long userId = principal.getUserId();
+		Long userId = principal != null ? principal.getUserId() : null;
 		return issueServiceV1.fetchV2(issueId, userId, page);
 	}
 
@@ -88,7 +88,7 @@ public class IssueControllerV1 implements IssueControllerV1Docs {
 		@RequestParam(name = "page", required = false) Long page,
 		@AuthenticationPrincipal CustomUserDetails principal
 	) {
-		Long userId = principal.getUserId();
+		Long userId = principal != null ? principal.getUserId() : null;
 		return chatRoomServiceV1.findVotedChatRoom(userId,page);
 
 	}

--- a/src/main/java/com/debateseason_backend_v1/domain/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/user/presentation/controller/UserControllerV1.java
@@ -68,14 +68,8 @@ public class UserControllerV1 implements UserControllerV1Docs {
 		description = " ")
 	@GetMapping("/home")
 	public ApiResult<List<IssueBriefResponse>> indexPage(
-		//@RequestParam(name = "page", required = false) Long page,
 		@AuthenticationPrincipal CustomUserDetails principal
 	) {
-		Long userId = principal.getUserId();
-		//return chatRoomServiceV1.findVotedChatRoom(userId,page);
-
-		// 활성도가 가장 높은 토론방 5개 표시
-
 		return issueServiceV1.fetchV1();
 	}
 

--- a/src/main/java/com/debateseason_backend_v1/security/component/SecurityPathMatcher.java
+++ b/src/main/java/com/debateseason_backend_v1/security/component/SecurityPathMatcher.java
@@ -1,6 +1,7 @@
 package com.debateseason_backend_v1.security.component;
 
-import static com.debateseason_backend_v1.config.WebSecurityConfig.*;
+import static com.debateseason_backend_v1.config.WebSecurityConfig.OPTIONAL_AUTH_URLS;
+import static com.debateseason_backend_v1.config.WebSecurityConfig.PUBLIC_URLS;
 
 import java.util.Arrays;
 
@@ -24,17 +25,28 @@ public class SecurityPathMatcher {
 	}
 
 	public boolean isPublicUrl(String requestURI) {
+		String path = removeContextPath(requestURI);
+		return Arrays.stream(PUBLIC_URLS)
+			.anyMatch(pattern -> pathMatcher.match(pattern, path));
+	}
 
-		String pathWithoutContext = requestURI;
-		if (!contextPath.isEmpty() && requestURI.startsWith(contextPath)) {
-			pathWithoutContext = requestURI.substring(contextPath.length());
+	public boolean isOptionalAuthUrl(String requestURI, String method) {
+		String path = removeContextPath(requestURI);
+
+		// /api/v1/room은 GET만 Optional, POST는 Required Auth
+		if (pathMatcher.match("/api/v1/room", path)) {
+			return "GET".equalsIgnoreCase(method);
 		}
 
-		// 최종 값을 final 변수에 할당
-		final String finalPath = pathWithoutContext;
+		return Arrays.stream(OPTIONAL_AUTH_URLS)
+			.anyMatch(pattern -> pathMatcher.match(pattern, path));
+	}
 
-		return Arrays.stream(PUBLIC_URLS)
-			.anyMatch(pattern -> pathMatcher.match(pattern, finalPath));
+	private String removeContextPath(String requestURI) {
+		if (!contextPath.isEmpty() && requestURI.startsWith(contextPath)) {
+			return requestURI.substring(contextPath.length());
+		}
+		return requestURI;
 	}
 
 }

--- a/src/main/java/com/debateseason_backend_v1/security/filter/RateLimitFilter.java
+++ b/src/main/java/com/debateseason_backend_v1/security/filter/RateLimitFilter.java
@@ -1,0 +1,198 @@
+package com.debateseason_backend_v1.security.filter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.debateseason_backend_v1.common.exception.ErrorCode;
+import com.debateseason_backend_v1.common.response.ErrorResponse;
+import com.debateseason_backend_v1.security.CustomUserDetails;
+import com.debateseason_backend_v1.security.component.SecurityPathMatcher;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RateLimitFilter extends OncePerRequestFilter {
+
+	private static final String[] EXCLUDED_PATHS = {
+		"/swagger-ui/**",
+		"/actuator/**",
+		"/ws-stomp/**"
+	};
+
+	private static final long ENTRY_EXPIRATION_MILLIS = TimeUnit.MINUTES.toMillis(10);
+	private static final long CLEANUP_INTERVAL_MINUTES = 5;
+
+	private final SecurityPathMatcher securityPathMatcher;
+	private final ObjectMapper objectMapper;
+	private final long anonymousRateLimit;
+	private final long authenticatedRateLimit;
+
+	private final ConcurrentHashMap<String, BucketEntry> buckets = new ConcurrentHashMap<>();
+	private final ScheduledExecutorService cleanupExecutor;
+
+	public RateLimitFilter(
+		SecurityPathMatcher securityPathMatcher,
+		ObjectMapper objectMapper,
+		long anonymousRateLimit,
+		long authenticatedRateLimit
+	) {
+		this.securityPathMatcher = securityPathMatcher;
+		this.objectMapper = objectMapper;
+		this.anonymousRateLimit = anonymousRateLimit;
+		this.authenticatedRateLimit = authenticatedRateLimit;
+
+		this.cleanupExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+			Thread thread = new Thread(r, "rate-limit-cleanup");
+			thread.setDaemon(true);
+			return thread;
+		});
+
+		this.cleanupExecutor.scheduleAtFixedRate(
+			this::cleanupExpiredEntries,
+			CLEANUP_INTERVAL_MINUTES,
+			CLEANUP_INTERVAL_MINUTES,
+			TimeUnit.MINUTES
+		);
+	}
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+
+		if (isExcluded(request.getRequestURI())) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		String bucketKey;
+		long rateLimit;
+
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (isAuthenticated(authentication)) {
+			CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+			bucketKey = "user:" + userDetails.getUserId();
+			rateLimit = authenticatedRateLimit;
+		} else {
+			bucketKey = "ip:" + resolveClientIp(request);
+			rateLimit = anonymousRateLimit;
+		}
+
+		BucketEntry entry = buckets.computeIfAbsent(bucketKey, k -> new BucketEntry(createBucket(rateLimit)));
+		entry.updateLastAccess();
+
+		ConsumptionProbe probe = entry.getBucket().tryConsumeAndReturnRemaining(1);
+
+		if (!probe.isConsumed()) {
+			long retryAfterSeconds = TimeUnit.NANOSECONDS.toSeconds(probe.getNanosToWaitForRefill()) + 1;
+			log.warn("Rate limit exceeded for key: {}, retry after: {}s", bucketKey, retryAfterSeconds);
+
+			response.setHeader("Retry-After", String.valueOf(retryAfterSeconds));
+			writeErrorResponse(response);
+			return;
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private boolean isAuthenticated(Authentication authentication) {
+		return authentication != null
+			&& authentication.isAuthenticated()
+			&& authentication.getPrincipal() instanceof CustomUserDetails;
+	}
+
+	private boolean isExcluded(String requestURI) {
+		org.springframework.util.AntPathMatcher pathMatcher = new org.springframework.util.AntPathMatcher();
+		for (String pattern : EXCLUDED_PATHS) {
+			if (pathMatcher.match(pattern, requestURI)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private String resolveClientIp(HttpServletRequest request) {
+		String xForwardedFor = request.getHeader("X-Forwarded-For");
+		if (xForwardedFor != null && !xForwardedFor.isBlank()) {
+			return xForwardedFor.split(",")[0].trim();
+		}
+		return request.getRemoteAddr();
+	}
+
+	private Bucket createBucket(long capacity) {
+		return Bucket.builder()
+			.addLimit(limit -> limit.capacity(capacity).refillGreedy(capacity, Duration.ofMinutes(1)))
+			.build();
+	}
+
+	private void writeErrorResponse(HttpServletResponse response) throws IOException {
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.RATE_LIMIT_EXCEEDED);
+
+		response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+		String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+		response.getWriter().write(jsonResponse);
+	}
+
+	private void cleanupExpiredEntries() {
+		long now = System.currentTimeMillis();
+		int removed = 0;
+
+		var iterator = buckets.entrySet().iterator();
+		while (iterator.hasNext()) {
+			var entry = iterator.next();
+			if (now - entry.getValue().getLastAccessTime() > ENTRY_EXPIRATION_MILLIS) {
+				iterator.remove();
+				removed++;
+			}
+		}
+
+		if (removed > 0) {
+			log.debug("Rate limit cleanup: removed {} expired entries, remaining: {}", removed, buckets.size());
+		}
+	}
+
+	private static class BucketEntry {
+		private final Bucket bucket;
+		private volatile long lastAccessTime;
+
+		BucketEntry(Bucket bucket) {
+			this.bucket = bucket;
+			this.lastAccessTime = System.currentTimeMillis();
+		}
+
+		Bucket getBucket() {
+			return bucket;
+		}
+
+		long getLastAccessTime() {
+			return lastAccessTime;
+		}
+
+		void updateLastAccess() {
+			this.lastAccessTime = System.currentTimeMillis();
+		}
+	}
+}

--- a/src/main/java/com/debateseason_backend_v1/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/debateseason_backend_v1/security/jwt/JwtAuthenticationFilter.java
@@ -45,6 +45,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			return;
 		}
 
+		// Optional Auth: 토큰 있으면 파싱, 없으면 anonymous로 통과
+		if (securityPathMatcher.isOptionalAuthUrl(requestURI, request.getMethod())) {
+			tryOptionalAuthentication(request);
+			filterChain.doFilter(request, response);
+			return;
+		}
+
 		// 1. Authorization 헤더 검증
 		String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
 
@@ -118,6 +125,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			"Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}",
 			authentication.getName(), requestURI
 		);
+	}
+
+	private void tryOptionalAuthentication(HttpServletRequest request) {
+		String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+		if (!containsValidHeader(authorizationHeader)) {
+			return;
+		}
+		String token = removeBearerPrefix(authorizationHeader);
+		if (token == null) {
+			return;
+		}
+		try {
+			authenticateWithAccessToken(token, request.getRequestURI());
+		} catch (Exception e) {
+			log.debug("Optional auth failed, continuing as anonymous: {}", e.getMessage());
+		}
 	}
 
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -25,6 +25,10 @@ jwt:
   refresh-token:
     expire-time: ${REFRESH_EXPIRE_TIME}
 
+rate-limit:
+  anonymous-requests-per-minute: 100
+  authenticated-requests-per-minute: 300
+
 logging:
   level:
     # 1) 루트 레벨

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,10 @@ chat:
     max-length: 500
     min-length: 1
 
+rate-limit:
+  anonymous-requests-per-minute: 100
+  authenticated-requests-per-minute: 300
+
 social:
   kakao:
     audience: 18af8def9522316a9c30d75d997df2b1

--- a/src/test/java/com/debateseason_backend_v1/integration/chat/ChatApiTest.java
+++ b/src/test/java/com/debateseason_backend_v1/integration/chat/ChatApiTest.java
@@ -7,6 +7,9 @@ import com.debateseason_backend_v1.common.response.ApiResult;
 import com.debateseason_backend_v1.domain.chat.presentation.dto.chat.response.ChatMessagesResponse;
 import com.debateseason_backend_v1.domain.chat.infrastructure.chat.ChatJpaRepository;
 import com.debateseason_backend_v1.domain.chat.infrastructure.chat.ChatEntity;
+import com.debateseason_backend_v1.domain.issue.infrastructure.entity.IssueEntity;
+import com.debateseason_backend_v1.domain.issue.infrastructure.repository.IssueJpaRepository;
+import com.debateseason_backend_v1.domain.repository.ChatRoomRepository;
 import com.debateseason_backend_v1.domain.repository.entity.ChatRoom;
 import com.debateseason_backend_v1.security.jwt.JwtUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,7 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.context.ApplicationContext;
 import org.springframework.http.*;
 import org.springframework.test.context.ActiveProfiles;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -43,13 +45,37 @@ public class ChatApiTest {
     @Autowired
     private ChatJpaRepository chatRepository;
 
+    @Autowired
+    private IssueJpaRepository issueRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
     private String baseUrl;
+    private ChatRoom savedChatRoom;
 
 
     @BeforeEach
     void setup(){
         this.baseUrl = "http://localhost:" + port + "/api/v1/chat";
 
+        // IssueEntity 저장 (ChatRoom의 FK 필수)
+        IssueEntity issue = IssueEntity.builder()
+                .title("테스트 이슈")
+                .majorCategory("정치")
+                .build();
+        IssueEntity savedIssue = issueRepository.save(issue);
+
+        // ChatRoom 저장 (ChatEntity의 FK 필수)
+        savedChatRoom = ChatRoom.builder()
+                .issueEntity(savedIssue)
+                .title("테스트 채팅방")
+                .content("테스트 채팅방 내용")
+                .build();
+        savedChatRoom = chatRoomRepository.save(savedChatRoom);
     }
 
 
@@ -57,11 +83,11 @@ public class ChatApiTest {
     @Test
     void 채팅메시지_조회_성공() throws Exception {
         //given
-        Long roomId = 1L;
+        Long roomId = savedChatRoom.getId();
         Long userId = 99L;
 
         int messageCount = 50;
-        List<ChatEntity> chats = prepareTestChatMessages(roomId, messageCount);
+        List<ChatEntity> chats = prepareTestChatMessages(savedChatRoom, messageCount);
         String apiUrl = baseUrl + "/rooms/" + roomId + "/messages";
         System.out.println("@@@ apiUrl: " + apiUrl);
         //when
@@ -92,23 +118,12 @@ public class ChatApiTest {
     }
 
 
-    @Autowired private JwtUtil jwtUtil;
-    private String createTestJwt(Long userId) {
-        return jwtUtil.createAccessToken(userId);
-    }
-
-
-    @Autowired
-    private ApplicationContext context;
     /**
      * 테스트에 필요한 채팅 메시지를 데이터베이스에 준비하는 메서드
      * @param count count만큼 채팅메시지가 생성 된다.
-     * @param roomId 채팅 메시지를 생성할 roomId
+     * @param chatRoom DB에 저장된 채팅방 엔티티
      */
-    private List<ChatEntity> prepareTestChatMessages(Long roomId, int count) {
-        ChatRoom chatRoom = new ChatRoom();
-        chatRoom.setId(roomId);
-
+    private List<ChatEntity> prepareTestChatMessages(ChatRoom chatRoom, int count) {
         List<ChatEntity> savedChats = new ArrayList<>();
         for (int i = 1; i <= count; i++) {
             ChatEntity chat = ChatEntity.builder()

--- a/src/test/java/com/debateseason_backend_v1/integration/chat/ChatWebSocketTest.java
+++ b/src/test/java/com/debateseason_backend_v1/integration/chat/ChatWebSocketTest.java
@@ -4,9 +4,14 @@ import com.debateseason_backend_v1.common.enums.MessageType;
 import com.debateseason_backend_v1.common.enums.OpinionType;
 import com.debateseason_backend_v1.domain.chat.presentation.dto.chat.request.ChatMessageRequest;
 import com.debateseason_backend_v1.domain.chat.presentation.dto.chat.response.ChatMessageResponse;
+import com.debateseason_backend_v1.domain.issue.infrastructure.entity.IssueEntity;
+import com.debateseason_backend_v1.domain.issue.infrastructure.repository.IssueJpaRepository;
+import com.debateseason_backend_v1.domain.repository.ChatRoomRepository;
+import com.debateseason_backend_v1.domain.repository.entity.ChatRoom;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
@@ -34,6 +39,14 @@ public class ChatWebSocketTest {
     private final BlockingQueue<ChatMessageResponse> messageQueue = new LinkedBlockingQueue<>();
     private String WS_URL;
 
+    @Autowired
+    private IssueJpaRepository issueRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    private ChatRoom savedChatRoom;
+
     @BeforeEach
     void setup(){
         this.stompClient = new WebSocketStompClient(new StandardWebSocketClient());
@@ -41,16 +54,29 @@ public class ChatWebSocketTest {
         this.WS_URL = "ws://localhost:" + port + "/ws-stomp";
 
         messageQueue.clear();
+
+        // IssueEntity 저장 (ChatRoom의 FK 필수)
+        IssueEntity issue = IssueEntity.builder()
+                .title("테스트 이슈")
+                .majorCategory("정치")
+                .build();
+        IssueEntity savedIssue = issueRepository.save(issue);
+
+        // ChatRoom 저장 (WebSocket 메시지 처리 시 DB 조회 필수)
+        savedChatRoom = ChatRoom.builder()
+                .issueEntity(savedIssue)
+                .title("테스트 채팅방")
+                .content("테스트 채팅방 내용")
+                .build();
+        savedChatRoom = chatRoomRepository.save(savedChatRoom);
     }
-
-
 
 
     @Test
     void 채팅메시지_전송_및_수신_성공() throws Exception {
         System.out.println("USING WS_URL = " + WS_URL);
         //given
-        Long roomId = 1L;
+        Long roomId = savedChatRoom.getId();
         String sender = "testSender";
         String message = "testMessage";
         String userCommunity = "에펨코리아";
@@ -96,8 +122,6 @@ public class ChatWebSocketTest {
         assertEquals(receivedMessage.getOpinionType(), OpinionType.AGREE);
         assertEquals(receivedMessage.getUserCommunity(), userCommunity);
     }
-
-
 
 
 }


### PR DESCRIPTION
## 📌 변경 사항
웹(Next.js) 확장을 위한 3-Tier 인증 레벨(Public/Optional Auth/Required Auth) 아키텍처 도입 및 Bucket4j 기반 Rate Limiting 적용

## 🔍 관련 이슈
- 

## ✨ 작업 내용
1. **3-Tier 인증 레벨 아키텍처 구현** — 비로그인 사용자가 이슈/토론 열람 가능하도록 Optional Auth URL 분기 추가 (6개 엔드포인트)
2. **컨트롤러/서비스 null-safe 처리** — `@AuthenticationPrincipal`이 null인 경우 안전하게 기본값 반환 (IssueController, ChatRoomController, IssueService, ChatRoomService)
3. **Rate Limiting 구현** — JwtAuthenticationFilter 뒤에서 동작하는 RateLimitFilter 추가 (비로그인 IP당 100 req/min, 로그인 userId당 300 req/min, 초과 시 429 + Retry-After)
4. **도메인 마이그레이션 및 설정 정리** — 환경별 설정 분리, data.sql 백업 파일 이름 변경

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수하였나요?
- [x] 불필요한 코드가 남아있지 않나요?
- [x] 테스트는 완료하셨나요?

## 📝 리뷰어 참고 사항
- 기존 모바일 앱은 항상 토큰을 보내므로 Optional Auth 변경에 영향 없음
- Rate Limiting은 Swagger(`/swagger-ui/**`), Actuator(`/actuator/**`), WebSocket(`/ws-stomp/**`)에는 미적용
- 설정값(`rate-limit.anonymous/authenticated-requests-per-minute`)은 application.yml / application-prod.yml에서 독립 조정 가능
- 기존 실패 테스트 2개(ChatApiTest, ChatWebSocketTest)는 이번 변경과 무관한 기존 실패
- 상세 변경 이력: `docs/backend-vive-edit-history.md` 참조