### PR TITLE
develop → main 배포

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/domain/chat/application/service/ChatServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/application/service/ChatServiceV1.java
@@ -19,6 +19,8 @@ import com.debateseason_backend_v1.domain.chat.application.repository.ReportRepo
 import com.debateseason_backend_v1.domain.chat.domain.model.report.Report;
 import com.debateseason_backend_v1.domain.chat.domain.model.report.ReportStatus;
 import com.debateseason_backend_v1.domain.chat.domain.model.report.ReportTargetType;
+import com.debateseason_backend_v1.domain.profile.infrastructure.ProfileEntity;
+import com.debateseason_backend_v1.domain.profile.infrastructure.ProfileJpaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -30,6 +32,7 @@ import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -46,6 +49,7 @@ public class ChatServiceV1 {
 	private final ChatReactionRepository chatReactionRepository;
 	private final ReportRepository reportRepository;
     private final NotificationServiceV1 notificationService;
+	private final ProfileJpaRepository profileJpaRepository;
 
 	// ---------- WebSocket 실시간 메시지 처리 ----------
 	
@@ -67,12 +71,16 @@ public class ChatServiceV1 {
 		ChatEntity chat = ChatEntity.from(message, chatRoom, userId);
 		ChatEntity savedchat = chatRepository.save(chat);
 
-		// 비동기 FCM 알림 전송 (오프라인 사용자 푸시)
-		// notificationService.sendChatMessageNotification(savedchat);
-		// log.debug("채팅 메시지 저장 완료: roomId={}, sender={}", roomId, message.getSender());
+		// 프로필 색상 조회
+		String profileColor = null;
+		if (userId != null) {
+			profileColor = profileJpaRepository.findByUserId(userId)
+				.map(ProfileEntity::getProfileImage)
+				.orElse(null);
+		}
 
 		// 빈 반응 정보를 포함한 응답 생성
-		return ChatMessageResponse.from(savedchat);
+		return ChatMessageResponse.from(savedchat, profileColor);
 	}
 
 	public ChatMessageResponse processJoinMessage(ChatMessageRequest joinRequest) {
@@ -125,6 +133,15 @@ public class ChatServiceV1 {
 		boolean hasMore = chats.size() > PAGE_SIZE;
 		List<ChatEntity> displayChats = hasMore ? chats.subList(0, PAGE_SIZE) : chats;
 		
+		// 프로필 색상 배치 조회
+		List<Long> userIds = displayChats.stream()
+				.map(ChatEntity::getUserId)
+				.filter(Objects::nonNull)
+				.distinct()
+				.toList();
+		Map<Long, String> profileColorMap = profileJpaRepository.findByUserIdIn(userIds).stream()
+				.collect(Collectors.toMap(ProfileEntity::getUserId, ProfileEntity::getProfileImage, (a, b) -> a));
+
 		// 신고된 메시지 목록 조회
 		Set<Long> acceptedReportChatIds = reportRepository.findByTargetTypeAndStatus(
 				ReportTargetType.CHAT, ReportStatus.ACCEPTED)
@@ -138,6 +155,9 @@ public class ChatServiceV1 {
 		// 응답 생성 - 신고된 메시지 마스킹 적용
 		List<ChatMessageResponse> messageResponses = displayChats.stream()
 				.map(chatEntity -> {
+					String profileColor = chatEntity.getUserId() != null
+							? profileColorMap.getOrDefault(chatEntity.getUserId(), null)
+							: null;
 					// 신고 처리된 메시지인지 확인
 					if (acceptedReportChatIds.contains(chatEntity.getId())) {
 						// 마스킹된 엔티티 생성
@@ -152,9 +172,9 @@ public class ChatServiceV1 {
 								.userCommunity(chatEntity.getUserCommunity())
 								.timeStamp(chatEntity.getTimeStamp())
 								.build();
-						return ChatMessageResponse.from(maskedEntity, userId, chatReactionRepository);
+						return ChatMessageResponse.from(maskedEntity, userId, chatReactionRepository, profileColor);
 					}
-					return ChatMessageResponse.from(chatEntity, userId, chatReactionRepository);
+					return ChatMessageResponse.from(chatEntity, userId, chatReactionRepository, profileColor);
 				})
 				.collect(Collectors.toList());
 		
@@ -201,6 +221,15 @@ public class ChatServiceV1 {
 		//chatIds 메시지들 사용자 반응
 		Map<Long, Set<ChatReactionRequest.ReactionType>> userReactionsMap = chatReactionRepository.findUserReactionsByChatIdsIn(chatIds, userId);
 
+		// 프로필 색상 배치 조회
+		List<Long> userIds = displayChats.stream()
+				.map(ChatEntity::getUserId)
+				.filter(Objects::nonNull)
+				.distinct()
+				.toList();
+		Map<Long, String> profileColorMap = profileJpaRepository.findByUserIdIn(userIds).stream()
+				.collect(Collectors.toMap(ProfileEntity::getUserId, ProfileEntity::getProfileImage, (a, b) -> a));
+
 		//신고 메시지 처리 로직
 		Set<Long> acceptedReportChatIds = reportRepository.findByTargetTypeAndStatus(
 						ReportTargetType.CHAT, ReportStatus.ACCEPTED)
@@ -215,12 +244,11 @@ public class ChatServiceV1 {
 				.map(chatEntity -> {
 					if (acceptedReportChatIds.contains(chatEntity.getId())) {
 						ChatEntity maskedEntity = createMaskedEntity(chatEntity);
-						// 새로운 최적화된 메서드 사용
 						return ChatMessageResponse.fromOptimized(
-								maskedEntity, userId, reactionCountsMap, userReactionsMap);
+								maskedEntity, userId, reactionCountsMap, userReactionsMap, profileColorMap);
 					}
 					return ChatMessageResponse.fromOptimized(
-							chatEntity, userId, reactionCountsMap, userReactionsMap);
+							chatEntity, userId, reactionCountsMap, userReactionsMap, profileColorMap);
 				})
 				.toList();
 

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/presentation/dto/chat/response/ChatMessageResponse.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/presentation/dto/chat/response/ChatMessageResponse.java
@@ -45,6 +45,8 @@ public class ChatMessageResponse {
     private OpinionType opinionType;
     @Schema(description = "사용자 소속 커뮤니티", example = "에펨코리아")
     private String userCommunity;
+    @Schema(description = "프로필 색상", example = "RED")
+    private String profileColor;
 
     @JsonSerialize(using = LocalDateTimeSerializer.class) // 직렬화 시 필요
     @JsonDeserialize(using = LocalDateTimeDeserializer.class) // 역직렬화 시 필요
@@ -67,6 +69,10 @@ public class ChatMessageResponse {
     }
 
     public static ChatMessageResponse from(ChatEntity chat, Long currentUserId, ChatReactionRepository chatReactionRepository) {
+        return from(chat, currentUserId, chatReactionRepository, null);
+    }
+
+    public static ChatMessageResponse from(ChatEntity chat, Long currentUserId, ChatReactionRepository chatReactionRepository, String profileColor) {
         // 반응 수 조회
         int logicCount = chatReactionRepository.countByChatIdAndReactionType(
                 chat.getId(), ChatReactionRequest.ReactionType.LOGIC);
@@ -92,6 +98,7 @@ public class ChatMessageResponse {
                 .sender(chat.getSender())
                 .opinionType(chat.getOpinionType())
                 .userCommunity(chat.getUserCommunity())
+                .profileColor(profileColor)
                 .timeStamp(chat.getTimeStamp())
                 .reactions(ChatReactionResponse.builder()
                         .logicCount(logicCount)
@@ -103,6 +110,10 @@ public class ChatMessageResponse {
     }
 
     public static ChatMessageResponse from(ChatEntity chat) {
+        return from(chat, (String) null);
+    }
+
+    public static ChatMessageResponse from(ChatEntity chat, String profileColor) {
         // 빈 ReactionResponse 객체 생성
         ChatReactionResponse emptyReaction = ChatReactionResponse.builder()
                 .logicCount(0)
@@ -119,6 +130,7 @@ public class ChatMessageResponse {
                 .sender(chat.getSender())
                 .opinionType(chat.getOpinionType())
                 .userCommunity(chat.getUserCommunity())
+                .profileColor(profileColor)
                 .timeStamp(chat.getTimeStamp())
                 .reactions(emptyReaction)
                 .build();
@@ -140,37 +152,25 @@ public class ChatMessageResponse {
             ChatEntity chat,
             Long currentUserId,
             Map<Long, Map<ChatReactionRequest.ReactionType, Integer>> reactionCountsMap,
-            Map<Long, Set<ChatReactionRequest.ReactionType>> userReactionsMap) {
+            Map<Long, Set<ChatReactionRequest.ReactionType>> userReactionsMap,
+            Map<Long, String> profileColorMap) {
 
-        /**
-         * Map에서 반응 수 가져오기
-         *
-         * getOrDefault 사용 이유
-         * 1. 반응이 하나도 없는 메시지일 수 있음
-         * 2. null 체크 없이 안전하게 기본값 반환
-         * 3. 함수형 프로그래밍 스타일로 가독성 향상
-         */
         Map<ChatReactionRequest.ReactionType, Integer> reactionCounts =
                 reactionCountsMap.getOrDefault(chat.getId(), Collections.emptyMap());
 
-        // 각 타입별 반응 수 (없으면 0)
         int logicCount = reactionCounts.getOrDefault(ChatReactionRequest.ReactionType.LOGIC, 0);
         int attitudeCount = reactionCounts.getOrDefault(ChatReactionRequest.ReactionType.ATTITUDE, 0);
 
-        /**
-         * 사용자 반응 여부 확인
-         *
-         * Set.contains() 사용 이유
-         * 1. O(1) 시간 복잡도로 빠른 조회
-         * 2. null-safe (빈 Set은 항상 false 반환)
-         */
         Set<ChatReactionRequest.ReactionType> userReactions =
                 userReactionsMap.getOrDefault(chat.getId(), Collections.emptySet());
 
         boolean userReactedLogic = userReactions.contains(ChatReactionRequest.ReactionType.LOGIC);
         boolean userReactedAttitude = userReactions.contains(ChatReactionRequest.ReactionType.ATTITUDE);
 
-        // 빌더 패턴으로 응답 객체 생성
+        String profileColor = chat.getUserId() != null
+                ? profileColorMap.getOrDefault(chat.getUserId(), null)
+                : null;
+
         return ChatMessageResponse.builder()
                 .id(chat.getId())
                 .roomId(chat.getChatRoomId().getId())
@@ -179,6 +179,7 @@ public class ChatMessageResponse {
                 .sender(chat.getSender())
                 .opinionType(chat.getOpinionType())
                 .userCommunity(chat.getUserCommunity())
+                .profileColor(profileColor)
                 .timeStamp(chat.getTimeStamp())
                 .reactions(ChatReactionResponse.builder()
                         .logicCount(logicCount)

--- a/src/main/java/com/debateseason_backend_v1/domain/profile/infrastructure/ProfileJpaRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/profile/infrastructure/ProfileJpaRepository.java
@@ -1,5 +1,6 @@
 package com.debateseason_backend_v1.domain.profile.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +14,6 @@ public interface ProfileJpaRepository extends JpaRepository<ProfileEntity, Long>
 	boolean existsByNickname(String nickname);
 
 	Optional<ProfileEntity> findByUserId(Long userId);
+
+	List<ProfileEntity> findByUserIdIn(List<Long> userIds);
 }


### PR DESCRIPTION
## Summary
- Media API 응답에 category, media, createdAt 필드 추가 및 category 매핑 버그 수정
- authorizeHttpRequests를 anyRequest().permitAll()로 간소화
- getSortedCommunity() NPE 방어 (비로그인 시 userList null)
- requestMatchers를 AntPathRequestMatcher로 변경하여 /api/v1/issue 403 해결
- CI/CD 배포 시 고스트 프로세스 kill 추가
- SecurityPathMatcher context-path 수정

## Test plan
- [ ] Media API에서 category, media, createdAt 필드가 정상 반환되는지 확인
- [ ] 비로그인 상태에서 커뮤니티 정렬 시 NPE 발생하지 않는지 확인
- [ ] /api/v1/issue 엔드포인트 403 없이 정상 접근 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)