### PR TITLE
feat: API를 api.toronchul.app 서브도메인으로 분리 및 채팅 WebSocket 인증 게이트 추가

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/config/WebConfig.java
+++ b/src/main/java/com/debateseason_backend_v1/config/WebConfig.java
@@ -11,10 +11,12 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**") //모든 경로 허용
-			.allowedOrigins(
+			.allowedOriginPatterns(
 				"https://debate-season.click",
 				"http://localhost:3000",
-				"https://toronchul.app"
+				"https://toronchul.app",
+				"https://www.toronchul.app",
+				"https://*.vercel.app"
 			)
 			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
 			.allowedHeaders("*")

--- a/src/main/java/com/debateseason_backend_v1/config/WebSocketConfig.java
+++ b/src/main/java/com/debateseason_backend_v1/config/WebSocketConfig.java
@@ -44,6 +44,12 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Value("${stomp-connect-url}")
     private String stompConnectUrl;
 
+    // true 이면 토큰 없는/유효하지 않은 STOMP CONNECT 를 거부한다.
+    // 기존(미업데이트) 앱은 CONNECT 에 토큰을 싣지 않으므로, 앱 강제 업데이트 배포가 끝난 뒤에만 true 로 켠다.
+    // 기본값 false: 토큰이 있으면 사용자 식별, 없으면 익명 연결 허용(기존 클라이언트 호환).
+    @Value("${chat.websocket.auth-required:false}")
+    private boolean webSocketAuthRequired;
+
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
         config.enableSimpleBroker("/topic", "/queue");
@@ -84,36 +90,45 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
             @Override
             public Message<?> preSend(Message<?> message, MessageChannel channel) {
                 StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-                
-                if (StompCommand.CONNECT.equals(accessor.getCommand())) {
-                    String token = accessor.getFirstNativeHeader("Authorization");
-                    log.info("WebSocket 연결 시도 - 토큰: {}", token != null ? "존재함" : "없음");
-                    
-                    if (token != null && token.startsWith("Bearer ")) {
-                        token = token.substring(7);
-                        try {
-                            // 토큰 검증
-                            jwtUtil.validate(token);
-                            
-                            // 사용자 ID 추출
-                            Long userId = jwtUtil.getUserId(token);
-                            log.info("WebSocket 인증 성공 - 사용자 ID: {}", userId);
-                            
-                            accessor.setUser(new Principal() {
-                                @Override
-                                public String getName() {
-                                    return userId.toString();
-                                }
-                            });
-                        } catch (Exception e) {
-                            // 토큰 검증 실패 시 처리
-                            log.error("토큰 검증 실패: {}", e.getMessage());
-                            throw new MessageDeliveryException("Invalid JWT token");
-                        }
-                    } else {
-                        log.warn("Authorization 헤더가 없거나 Bearer 토큰이 아닙니다");
-                    }
+
+                if (accessor == null || !StompCommand.CONNECT.equals(accessor.getCommand())) {
+                    return message;
                 }
+
+                // 채팅 메시지에 user_id 를 저장하려면 CONNECT 시점에 사용자를 식별해야 한다.
+                // (식별 실패 시 메시지가 익명으로 저장되어 프로필 색상이 전부 null 이 된다.)
+                String authorization = accessor.getFirstNativeHeader("Authorization");
+
+                if (authorization == null || !authorization.startsWith("Bearer ")) {
+                    if (webSocketAuthRequired) {
+                        log.warn("WebSocket CONNECT 거부 - Authorization 헤더 없음 또는 형식 오류");
+                        throw new MessageDeliveryException("WebSocket 연결에는 인증 토큰이 필요합니다.");
+                    }
+                    // 비강제 모드: 기존 클라이언트 호환을 위해 익명 연결 허용
+                    log.warn("WebSocket 익명 연결 - Authorization 헤더 없음 (메시지가 user_id 없이 저장됨)");
+                    return message;
+                }
+
+                String token = authorization.substring(7);
+                try {
+                    jwtUtil.validate(token);
+                    Long userId = jwtUtil.getUserId(token);
+
+                    accessor.setUser(new Principal() {
+                        @Override
+                        public String getName() {
+                            return userId.toString();
+                        }
+                    });
+                    log.info("WebSocket 인증 성공 - 사용자 ID: {}", userId);
+                } catch (Exception e) {
+                    log.error("WebSocket CONNECT - 토큰 검증 실패: {}", e.getMessage());
+                    if (webSocketAuthRequired) {
+                        throw new MessageDeliveryException("유효하지 않은 인증 토큰입니다.");
+                    }
+                    // 비강제 모드: 토큰이 유효하지 않아도 익명으로 연결 허용
+                }
+
                 return message;
             }
         });

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -87,10 +87,17 @@ server:
   port: 8080
 
 # 환경별로 스웨거 요청 분리
-swagger-base-url: "https://toronchul.app/prod"
+swagger-base-url: "https://api.toronchul.app/prod"
 
 #stomp 연결 환경분리
 stomp-connect-url: "/ws-stomp"
+
+# 채팅 WebSocket 인증 강제 여부.
+# false: 토큰 있으면 사용자 식별, 없으면 익명 연결 허용(기존 앱 호환).
+# true: 토큰 없는/유효하지 않은 CONNECT 거부 → 앱 강제 업데이트 배포 완료 후에만 켤 것.
+chat:
+  websocket:
+    auth-required: false
 
 # 유튜브 라이브 api key (환경변수로 관리)
 youtube_live-api-key: ${YOUTUBE_API_KEY}


### PR DESCRIPTION
## 개요
이번 세션 작업 두 가지를 묶었습니다.
1. **API 도메인 분리**: API를 `api.toronchul.app` 서브도메인으로 분리
2. **채팅 WebSocket 인증 게이트**: 채팅 메시지가 익명(`user_id` null)으로 저장되어 프로필 색상이 전원 동일색으로 보이던 문제의 백엔드 측 대응

## 변경 사항

### 1. API 서브도메인 분리
- `application-prod.yml`: `swagger-base-url` → `https://api.toronchul.app/prod`
- `WebConfig.java`: CORS `allowedOrigins` → `allowedOriginPatterns` 전환
  - 기존 출처(`debate-season.click`, `localhost:3000`, `toronchul.app`) 유지
  - `https://www.toronchul.app`, `https://*.vercel.app`(프리뷰) 추가
- dev 환경(`application-dev.yml`), `WebSocketConfig`의 `setAllowedOrigins("*")`는 의도적으로 미변경

### 2. 채팅 WebSocket 인증 게이트
- `WebSocketConfig.java`: STOMP `CONNECT` 인증을 `chat.websocket.auth-required` 플래그로 게이트
  - **기본 `false`**: 토큰 있으면 `user_id` 식별, 없으면 익명 연결 허용 → **기존(미업데이트) 앱 호환**
  - `true`: 토큰 없는/유효하지 않은 `CONNECT` 거부 → 익명 메시지 원천 차단
  - `accessor` null-safety 보강(기존 코드 NPE 가능성 제거)
- `application-prod.yml`: `chat.websocket.auth-required: false` 추가

## 배경 (채팅 색상 버그)
- 프로덕션 채팅 메시지 381건 전부 `user_id = NULL`(인증 캡처 기능 도입 이후 198건 포함) → 백엔드가 `profileColor`를 항상 `null`로 응답 → 클라이언트가 기본색(노랑)으로 렌더.
- 원인: STOMP `CONNECT`에 토큰을 싣지 않아 사용자 식별 실패 + 익명 연결 허용.
- **프론트 측 수정**(토큰 전송 / `profileColor` 파싱 / 색상 하드코딩 제거)이 별도 필요(프론트 레포 `docs/chat-profile-color-fix.md`로 전달).

## ⚠️ 배포 순서 (중요)
`chat.websocket.auth-required`는 기본 `false`라 **이 PR은 단독 배포해도 기존 앱이 깨지지 않습니다.**
`true`로 켜는 것은 반드시 다음 순서 이후:
1. 프론트(STOMP CONNECT 토큰 전송) 배포
2. 앱 강제 업데이트 완료
3. 백엔드 플래그 `true` + 재시작

## 검증
- `./gradlew compileJava` 통과
- `api.toronchul.app/prod` 라우팅·TLS(SAN에 api 포함) 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)