### PR TITLE
fix(v1.3.5): optional-auth 만료·무효 토큰을 익명 강등 대신 401 반환

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/debateseason_backend_v1/security/jwt/JwtAuthenticationFilter.java
@@ -45,14 +45,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			return;
 		}
 
-		// Optional Auth: 토큰 있으면 파싱, 없으면 anonymous로 통과
+		// Optional Auth: 헤더가 없으면 익명으로 통과, 헤더가 있으면 토큰 유효성을 강제한다.
+		// "헤더 없음(진짜 비로그인)" 과 "토큰은 있으나 만료/무효" 를 구분해, 후자는 익명으로
+		// 조용히 강등하지 않고 401 을 돌려준다. 그래야 클라이언트의 401 기반 리프레시가 동작한다.
 		if (securityPathMatcher.isOptionalAuthUrl(request)) {
-			tryOptionalAuthentication(request);
+			String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+			if (containsValidHeader(authorizationHeader)
+				&& !authenticateFromHeader(authorizationHeader, response, requestURI)) {
+				// 헤더는 있으나 토큰이 만료/무효 -> 401 을 이미 기록했으므로 체인 중단
+				return;
+			}
+			// 헤더가 없으면 순수 비로그인 -> 익명 응답 유지
 			filterChain.doFilter(request, response);
 			return;
 		}
 
-		// 1. Authorization 헤더 검증
+		// Authorization 헤더 검증 (필수 인증)
 		String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
 
 		if (!containsValidHeader(authorizationHeader)) {
@@ -61,24 +69,44 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			return;
 		}
 
-		// 2. Bearer 토큰 추출
+		if (!authenticateFromHeader(authorizationHeader, response, requestURI)) {
+			return;
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	/**
+	 * 헤더에 실린 Bearer 토큰을 검증해 SecurityContext 에 인증을 세팅한다.
+	 * 성공하면 {@code true}, 실패하면 401(만료/무효)을 응답에 기록하고 {@code false} 를 반환한다.
+	 * (호출 측은 {@code false} 면 필터 체인을 중단해야 한다.)
+	 *
+	 * <p>검증 실패 처리는 필수 인증과 optional 인증이 공유한다 -> 두 경로의 정책이 항상 일치한다.
+	 * 인증 처리만 try 로 감싸고 {@code filterChain.doFilter} 는 호출 측에 두므로,
+	 * 다운스트림 컨트롤러가 던진 예외를 여기서 삼켜 401 로 오인하는 일은 없다.
+	 */
+	private boolean authenticateFromHeader(
+		String authorizationHeader,
+		HttpServletResponse response,
+		String requestURI
+	) throws IOException {
+
 		String token = removeBearerPrefix(authorizationHeader);
 		if (token == null) {
 			log.debug("유효한 JWT 토큰 형식이 아닙니다, uri: {}", requestURI);
 			errorHandler.handleInvalidToken(response, requestURI);
-			return;
+			return false;
 		}
 
-		// 3. 토큰 유효성 검증 및 인증 처리
 		try {
 			authenticateWithAccessToken(token, requestURI);
-			filterChain.doFilter(request, response);
+			return true;
 		} catch (ExpiredJwtException e) {
 			errorHandler.handleExpiredToken(response, requestURI);
-			return;
-		} catch (JwtException e) {
+			return false;
+		} catch (JwtException | IllegalArgumentException e) {
 			errorHandler.handleInvalidToken(response, requestURI);
-			return;
+			return false;
 		}
 	}
 
@@ -125,22 +153,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			"Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}",
 			authentication.getName(), requestURI
 		);
-	}
-
-	private void tryOptionalAuthentication(HttpServletRequest request) {
-		String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
-		if (!containsValidHeader(authorizationHeader)) {
-			return;
-		}
-		String token = removeBearerPrefix(authorizationHeader);
-		if (token == null) {
-			return;
-		}
-		try {
-			authenticateWithAccessToken(token, request.getRequestURI());
-		} catch (Exception e) {
-			log.debug("Optional auth failed, continuing as anonymous: {}", e.getMessage());
-		}
 	}
 
 }

--- a/src/test/java/com/debateseason_backend_v1/security/jwt/OptionalAuthAccessTokenTest.java
+++ b/src/test/java/com/debateseason_backend_v1/security/jwt/OptionalAuthAccessTokenTest.java
@@ -1,0 +1,132 @@
+package com.debateseason_backend_v1.security.jwt;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.debateseason_backend_v1.common.enums.TokenType;
+import com.debateseason_backend_v1.common.exception.ErrorCode;
+import com.debateseason_backend_v1.domain.user.domain.UserRole;
+import com.debateseason_backend_v1.security.component.SecurityPathMatcher;
+import com.debateseason_backend_v1.security.error.JwtAuthenticationErrorHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.security.SignatureException;
+
+/**
+ * optional-auth 조회 엔드포인트의 토큰 처리 정합성 검증.
+ *
+ * <p>버그: 만료/무효 토큰을 실어 보내면 401 이 아니라 200 + 익명 응답으로 조용히 강등돼
+ * 클라이언트의 401 기반 리프레시가 트리거되지 않았다. 아래 계약을 고정한다.
+ * <ul>
+ *   <li>헤더 없음(진짜 비로그인) -> 200 (익명 응답 유지)</li>
+ *   <li>토큰 만료 -> 401 EXPIRED_ACCESS_TOKEN</li>
+ *   <li>토큰 서명 불일치/형식 오류 -> 401 INVALID_ACCESS_TOKEN</li>
+ * </ul>
+ */
+class OptionalAuthAccessTokenTest {
+
+	private JwtUtil jwtUtil;
+	private MockMvc mockMvc;
+
+	private static final String TOKEN = "test.jwt.token";
+	private static final String OPTIONAL_URL = "/api/v1/room";
+
+	@BeforeEach
+	void setUp() {
+		SecurityContextHolder.clearContext();
+		jwtUtil = Mockito.mock(JwtUtil.class);
+
+		JwtAuthenticationErrorHandler errorHandler =
+			new JwtAuthenticationErrorHandler(new ObjectMapper());
+		SecurityPathMatcher pathMatcher = new SecurityPathMatcher();
+		JwtAuthenticationFilter filter =
+			new JwtAuthenticationFilter(jwtUtil, errorHandler, pathMatcher);
+
+		mockMvc = MockMvcBuilders.standaloneSetup(new StubController())
+			.addFilters(filter)
+			.build();
+	}
+
+	@Test
+	@DisplayName("헤더가 없으면 익명으로 200 응답 (순수 비로그인 플로우 보존)")
+	void anonymousWhenNoHeader() throws Exception {
+		mockMvc.perform(get(OPTIONAL_URL))
+			.andExpect(status().isOk());
+
+		verify(jwtUtil, never()).validate(any());
+	}
+
+	@Test
+	@DisplayName("유효한 토큰이면 인증되어 200 응답")
+	void authenticatedWhenValidToken() throws Exception {
+		given(jwtUtil.validate(TOKEN)).willReturn(true);
+		given(jwtUtil.getTokenType(TOKEN)).willReturn(TokenType.ACCESS);
+		given(jwtUtil.getUserId(TOKEN)).willReturn(1L);
+		given(jwtUtil.getRole(TOKEN)).willReturn(UserRole.USER);
+
+		mockMvc.perform(get(OPTIONAL_URL)
+				.header("Authorization", "Bearer " + TOKEN))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName("만료된 토큰이면 익명 강등 대신 401 EXPIRED_ACCESS_TOKEN")
+	void unauthorizedWhenExpiredToken() throws Exception {
+		willThrow(new ExpiredJwtException(null, null, "expired"))
+			.given(jwtUtil).validate(TOKEN);
+
+		mockMvc.perform(get(OPTIONAL_URL)
+				.header("Authorization", "Bearer " + TOKEN))
+			.andExpect(status().isUnauthorized())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.value()))
+			.andExpect(jsonPath("$.code").value(ErrorCode.EXPIRED_ACCESS_TOKEN.name()));
+	}
+
+	@Test
+	@DisplayName("서명이 불일치하는 토큰이면 401 INVALID_ACCESS_TOKEN")
+	void unauthorizedWhenInvalidSignature() throws Exception {
+		willThrow(new SignatureException("invalid signature"))
+			.given(jwtUtil).validate(TOKEN);
+
+		mockMvc.perform(get(OPTIONAL_URL)
+				.header("Authorization", "Bearer " + TOKEN))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code").value(ErrorCode.INVALID_ACCESS_TOKEN.name()));
+	}
+
+	@Test
+	@DisplayName("Bearer 접두사가 없는 헤더면 401 INVALID_ACCESS_TOKEN")
+	void unauthorizedWhenNoBearerPrefix() throws Exception {
+		mockMvc.perform(get(OPTIONAL_URL)
+				.header("Authorization", "Basic " + TOKEN))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code").value(ErrorCode.INVALID_ACCESS_TOKEN.name()));
+
+		verify(jwtUtil, never()).validate(any());
+	}
+
+	@RestController
+	static class StubController {
+
+		@GetMapping(OPTIONAL_URL)
+		ResponseEntity<String> room() {
+			return ResponseEntity.ok("ok");
+		}
+	}
+}


### PR DESCRIPTION
## 현상
웹에서 하루 지나 재방문 시 로그인은 유지되나 찬반 투표가 전부 미투표(NEUTRAL)로 보이고 토론방 입장 버튼이 비활성화됨. optional-auth 조회 엔드포인트에 만료/무효 토큰을 실으면 401 이 아니라 `200 + opinion:"NEUTRAL"` 익명 응답이 내려가, 클라이언트의 401 기반 리프레시가 트리거되지 않음.

## 원인
`JwtAuthenticationFilter.tryOptionalAuthentication` 이 `catch(Exception)` 으로 만료·서명오류를 전부 삼키고 익명으로 통과시킴(silent downgrade). 필수 인증 경로는 이미 401 을 정확히 반환하고 있어 두 경로의 정책이 어긋나 있었음.

## 변경
- **헤더 없음**(진짜 비로그인) → **200 익명 응답 유지** (비로그인·모바일 플로우 보존)
- **헤더는 있으나 토큰 만료** → **401 `EXPIRED_ACCESS_TOKEN`**
- **헤더는 있으나 서명 불일치/형식 오류/Bearer 아님** → **401 `INVALID_ACCESS_TOKEN`**
- 검증 로직을 `authenticateFromHeader` 헬퍼로 추출해 필수 인증과 공유 → 모든 optional-auth 엔드포인트(`/api/v1/issue`, `/api/v1/room`, `/api/v1/home/*`, `/api/v1/users/home`)에 일관 적용
- `filterChain.doFilter` 를 try 밖으로 빼 다운스트림 컨트롤러 예외를 401 로 오인해 삼키던 잠재 위험 제거

## 테스트
`OptionalAuthAccessTokenTest` 신규: 헤더없음→200 / 유효토큰→200 / 만료→401 EXPIRED / 서명불일치→401 INVALID / Bearer아님→401 INVALID. 기존 `JwtAuthenticationFilterTest`·`AdminAuthorizationTest` 회귀 없음.

## 회귀 검토
헤더 없이 호출하는 순수 비로그인 조회는 200 익명 유지(코드·테스트로 보장). 만료 토큰을 실어 보내던 클라이언트는 이제 401 을 받으므로 앱의 401 핸들링(리프레시) 동작 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)