### PR TITLE
feat(v1.3.5): 스레드 통합 Phase 1 — Expand 스키마 + threadId 배선

### DIFF
--- a/docs/sql/v1.3.5-expand.sql
+++ b/docs/sql/v1.3.5-expand.sql
@@ -1,0 +1,29 @@
+-- v1.3.5 Expand — 채팅방 스레드 통합 (하위호환 스키마 추가)
+-- 적용 대상: prod (application-prod.yml 은 ddl-auto: none 이므로 수동 적용 필수)
+-- 성격: 추가만(additive). 구/신 클라이언트 모두 무영향. 데이터 이관은 별도(v1.3.5-migrate.sql, Phase 2).
+--
+-- ⚠ 순서: 이 DDL 을 prod 에 먼저 적용한 뒤에야 thread_id 를 쓰는 애플리케이션 코드를 배포할 수 있다.
+--        (코드를 먼저 배포하면 thread_id 컬럼이 없는 chat 테이블에 INSERT 가 실패한다.)
+-- MariaDB 10.6 / chat 386행 → 모든 ALTER 는 순간.
+
+-- 1) chat_room: 컨테이너/스레드 구분 + 컨테이너 역참조
+--    room_type NULL = 레거시 = THREAD 로 해석 (마이그레이션 전 기존 방)
+ALTER TABLE chat_room
+    ADD COLUMN room_type VARCHAR(16) NULL,
+    ADD COLUMN container_room_id BIGINT NULL;
+
+-- 2) chat: 스레드 참조 컬럼
+--    thread_id NULL = 미분류 (마이그레이션 전 기존 메시지 / 구 앱 전송분)
+ALTER TABLE chat
+    ADD COLUMN thread_id BIGINT NULL;
+
+-- 3) 커서/스레드 필터 인덱스
+--    chat 은 가장 빨리 커지는 테이블 — 인덱스 없이 스레드 필터를 열면 즉시 느려진다.
+ALTER TABLE chat
+    ADD INDEX idx_chat_room_cursor (chat_room_id, chat_id),
+    ADD INDEX idx_chat_thread_cursor (thread_id, chat_id);
+
+-- 롤백:
+-- ALTER TABLE chat DROP INDEX idx_chat_thread_cursor, DROP INDEX idx_chat_room_cursor;
+-- ALTER TABLE chat DROP COLUMN thread_id;
+-- ALTER TABLE chat_room DROP COLUMN container_room_id, DROP COLUMN room_type;

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/application/service/ChatServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/application/service/ChatServiceV1.java
@@ -108,6 +108,7 @@ public class ChatServiceV1 {
 	private ChatEntity convertToEntity(ChatMessageRequest message, ChatRoom chatRoom) {
 		return ChatEntity.builder()
 				.chatRoomId(chatRoom)
+				.threadId(message.getThreadId())
 				.sender(message.getSender())
 				.content(message.getContent())
 				.messageType(message.getMessageType())
@@ -163,6 +164,7 @@ public class ChatServiceV1 {
 						ChatEntity maskedEntity = ChatEntity.builder()
 								.id(chatEntity.getId())
 								.chatRoomId(chatEntity.getChatRoomId())
+								.threadId(chatEntity.getThreadId())
 								.userId(chatEntity.getUserId())
 								.messageType(chatEntity.getMessageType())
 								.content(Chat.REPORTED_MESSAGE_CONTENT)
@@ -275,6 +277,7 @@ public class ChatServiceV1 {
 		return ChatEntity.builder()
 				.id(original.getId())
 				.chatRoomId(original.getChatRoomId())
+				.threadId(original.getThreadId())
 				.userId(original.getUserId())
 				.messageType(original.getMessageType())
 				.content(Chat.REPORTED_MESSAGE_CONTENT)  // 신고된 메시지 내용으로 대체

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/infrastructure/chat/ChatEntity.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/infrastructure/chat/ChatEntity.java
@@ -29,6 +29,11 @@ public class ChatEntity {
 	@JoinColumn(name = "chat_room_id", nullable = false)
 	private ChatRoom chatRoomId;
 
+	// v1.3.5 채팅방 스레드 통합. 이 메시지가 속한 스레드(= 강등된 기존 방)의 id.
+	// NULL = 미분류 (마이그레이션 전 메시지 / 구 앱 전송분). 조회 필터는 chat_room_id(컨테이너) + thread_id.
+	@Column(name = "thread_id")
+	private Long threadId;
+
 	@Column(name = "user_id")
 	private Long userId;
 
@@ -58,6 +63,7 @@ public class ChatEntity {
 	public static ChatEntity from(ChatMessageRequest request, ChatRoom chatRoom, Long userId) {
 		return ChatEntity.builder()
 				.chatRoomId(chatRoom)
+				.threadId(request.getThreadId())
 				.userId(userId)
 				.messageType(request.getMessageType())
 				.content(request.getContent())

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/presentation/dto/chat/request/ChatMessageRequest.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/presentation/dto/chat/request/ChatMessageRequest.java
@@ -26,6 +26,8 @@ public class ChatMessageRequest {
 
     @Schema(description = "룸ID",example = "1L")
     private Long roomId;
+    @Schema(description = "스레드ID (선택). 웹은 선택 탭, 모바일은 미전송→기본 스레드. 미전송 시 null", example = "1L")
+    private Long threadId;
     @Schema(description = "메시지 타입", example = "CHAT")
     private MessageType messageType;
     @Schema(description = "메시지 내용 (메시지는 1자 이상 500자 이하여야 합니다.)" , example = "안녕하세요.")

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/presentation/dto/chat/response/ChatMessageResponse.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/presentation/dto/chat/response/ChatMessageResponse.java
@@ -32,8 +32,10 @@ public class ChatMessageResponse {
 
     @Schema(description = "채팅 ID",example = "1L")
     private Long id;
-    @Schema(description = "룸ID",example = "1L")
+    @Schema(description = "룸ID(컨테이너)",example = "1L")
     private Long roomId;
+    @Schema(description = "스레드ID. 웹이 탭 필터에 사용. 미분류 메시지는 null", example = "1L")
+    private Long threadId;
     @Schema(description = "메시지 타입", example = "CHAT")
     private MessageType messageType;
     @NotBlank(message= "메시지 내용은 필수 입니다.")
@@ -59,6 +61,7 @@ public class ChatMessageResponse {
 
     public static ChatMessageResponse from(ChatMessageRequest request) {
         return ChatMessageResponse.builder()
+                .threadId(request.getThreadId())
                 .messageType(request.getMessageType())
                 .sender(request.getSender())
                 .content(request.getContent())
@@ -93,6 +96,7 @@ public class ChatMessageResponse {
         return ChatMessageResponse.builder()
                 .id(chat.getId())
                 .roomId(chat.getChatRoomId().getId())
+                .threadId(chat.getThreadId())
                 .messageType(chat.getMessageType())
                 .content(chat.getContent())
                 .sender(chat.getSender())
@@ -125,6 +129,7 @@ public class ChatMessageResponse {
         return ChatMessageResponse.builder()
                 .id(chat.getId())
                 .roomId(chat.getChatRoomId().getId())
+                .threadId(chat.getThreadId())
                 .messageType(chat.getMessageType())
                 .content(chat.getContent())
                 .sender(chat.getSender())
@@ -174,6 +179,7 @@ public class ChatMessageResponse {
         return ChatMessageResponse.builder()
                 .id(chat.getId())
                 .roomId(chat.getChatRoomId().getId())
+                .threadId(chat.getThreadId())
                 .messageType(chat.getMessageType())
                 .content(chat.getContent())
                 .sender(chat.getSender())

--- a/src/main/java/com/debateseason_backend_v1/domain/chatroom/domain/ChatRoomType.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chatroom/domain/ChatRoomType.java
@@ -1,0 +1,20 @@
+package com.debateseason_backend_v1.domain.chatroom.domain;
+
+/**
+ * 채팅방의 역할 구분 (v1.3.5 채팅방 스레드 통합).
+ *
+ * 기존 chat_room 은 "안건 = 방 = 컨테이너" 3역을 겸했다. v1.3.5 에서 이슈당 방을 하나로 합치며
+ * 역할을 둘로 쪼갠다.
+ *
+ * <ul>
+ *   <li>{@link #CONTAINER} — 이슈당 1개. 모바일이 보는 채팅방이자 메시지 통합 버킷.</li>
+ *   <li>{@link #THREAD}    — 컨테이너 아래 스레드. 기존 방을 강등한 것. 찬반·멤버십·알림을 그대로 보유.</li>
+ * </ul>
+ *
+ * 레거시 행(마이그레이션 전)은 room_type 이 NULL 이며, THREAD 로 해석한다.
+ */
+public enum ChatRoomType {
+
+	CONTAINER,
+	THREAD
+}

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/entity/ChatRoom.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/entity/ChatRoom.java
@@ -7,6 +7,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.debateseason_backend_v1.domain.chatroom.domain.ChatRoomStatus;
+import com.debateseason_backend_v1.domain.chatroom.domain.ChatRoomType;
 import com.debateseason_backend_v1.domain.issue.infrastructure.entity.IssueEntity;
 
 import jakarta.persistence.Column;
@@ -52,6 +53,16 @@ public class ChatRoom {
 
 	private String title;
 	private String content;
+
+	// v1.3.5 채팅방 스레드 통합. 레거시 행은 NULL = THREAD 로 해석한다.
+	// CONTAINER = 이슈당 1개(모바일이 보는 방, 메시지 버킷), THREAD = 강등된 기존 방.
+	@Enumerated(EnumType.STRING)
+	@Column(name = "room_type")
+	private ChatRoomType roomType;
+
+	// THREAD 가 소속된 CONTAINER 방 id. CONTAINER/레거시 행은 NULL.
+	@Column(name = "container_room_id")
+	private Long containerRoomId;
 
 	// 레거시 행은 NULL(= 시스템/수동 생성). 소유권 판정 시 NULL 이면 ADMIN 만 수정 가능.
 	@Column(name = "created_by")

--- a/src/test/java/com/debateseason_backend_v1/domain/chat/ChatThreadIdPlumbingTest.java
+++ b/src/test/java/com/debateseason_backend_v1/domain/chat/ChatThreadIdPlumbingTest.java
@@ -1,0 +1,71 @@
+package com.debateseason_backend_v1.domain.chat;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.debateseason_backend_v1.common.enums.MessageType;
+import com.debateseason_backend_v1.domain.chat.infrastructure.chat.ChatEntity;
+import com.debateseason_backend_v1.domain.chat.presentation.dto.chat.request.ChatMessageRequest;
+import com.debateseason_backend_v1.domain.chat.presentation.dto.chat.response.ChatMessageResponse;
+import com.debateseason_backend_v1.domain.repository.entity.ChatRoom;
+
+/**
+ * v1.3.5 Phase 1 — threadId 배선 검증.
+ *
+ * 요청(ChatMessageRequest) → 엔티티(ChatEntity) → 응답(ChatMessageResponse) 로 threadId 가
+ * 유실 없이 흐르는지, 그리고 구 앱(threadId 미전송)은 NULL 로 안전하게 저장되는지 고정한다.
+ * 컨테이너 라우팅/스레드 필터 쿼리는 이후 Phase 소관이므로 여기서 다루지 않는다.
+ */
+class ChatThreadIdPlumbingTest {
+
+	private static final Long CONTAINER_ROOM_ID = 10L;
+	private static final Long THREAD_ID = 55L;
+
+	@Test
+	@DisplayName("threadId 가 요청→엔티티→응답으로 유실 없이 전달된다")
+	void threadIdRoundTrips() {
+		// given
+		ChatRoom container = ChatRoom.builder().id(CONTAINER_ROOM_ID).build();
+		ChatMessageRequest request = ChatMessageRequest.builder()
+			.roomId(CONTAINER_ROOM_ID)
+			.threadId(THREAD_ID)
+			.messageType(MessageType.CHAT)
+			.content("원전 확대 찬성합니다")
+			.sender("홍길동")
+			.build();
+
+		// when
+		ChatEntity entity = ChatEntity.from(request, container, 1L);
+		ChatMessageResponse response = ChatMessageResponse.from(entity, "RED");
+		ChatMessageResponse fromRequest = ChatMessageResponse.from(request);
+
+		// then
+		assertThat(entity.getThreadId()).isEqualTo(THREAD_ID);
+		assertThat(response.getThreadId()).isEqualTo(THREAD_ID);
+		assertThat(response.getRoomId()).isEqualTo(CONTAINER_ROOM_ID);
+		assertThat(fromRequest.getThreadId()).isEqualTo(THREAD_ID);
+	}
+
+	@Test
+	@DisplayName("구 앱처럼 threadId 를 안 보내면 NULL 로 저장된다 (미분류)")
+	void threadIdNullWhenAbsent() {
+		// given
+		ChatRoom room = ChatRoom.builder().id(CONTAINER_ROOM_ID).build();
+		ChatMessageRequest legacyRequest = ChatMessageRequest.builder()
+			.roomId(CONTAINER_ROOM_ID)
+			.messageType(MessageType.CHAT)
+			.content("구 앱 메시지")
+			.sender("구앱유저")
+			.build();
+
+		// when
+		ChatEntity entity = ChatEntity.from(legacyRequest, room, 1L);
+		ChatMessageResponse response = ChatMessageResponse.from(entity, null);
+
+		// then
+		assertThat(entity.getThreadId()).isNull();
+		assertThat(response.getThreadId()).isNull();
+	}
+}


### PR DESCRIPTION
PRD `docs/v1.3.5-chatroom-thread-merge-prd.md` 의 **Phase 1 (Expand)**. 추가만 하는 하위호환 단계.

## 변경
- `chat_room`: `room_type`(CONTAINER/THREAD) + `container_room_id` 컬럼, `ChatRoomType` enum
- `chat`: `thread_id`(nullable) 컬럼. 요청→엔티티→응답으로 `threadId` 배선 (신고 마스킹 빌더 2곳 포함 보존)
- `ChatMessageRequest`/`ChatMessageResponse` 에 `threadId` 필드 → STOMP 브로드캐스트 payload 자동 포함(웹 탭 필터 기반)
- `docs/sql/v1.3.5-expand.sql`: prod 수동 적용용 Expand DDL + 롤백
- `ChatThreadIdPlumbingTest`: threadId 왕복 + 구 앱 null 저장 검증

## 이번에 안 하는 것 (이후 Phase)
- 데이터 이관(컨테이너/전체스레드 생성, 기존 방 강등, 메시지 재지정) — Phase 2
- 컨테이너 라우팅·스레드 필터 히스토리 쿼리·방 목록 컨테이너 노출 — Phase 3

## ⚠ 머지·배포 전 필수 — DDL 선적용
prod 는 `ddl-auto: none`. **`docs/sql/v1.3.5-expand.sql` 을 prod 에 먼저 적용한 뒤에만** 이 PR 을 머지(=배포)해야 한다.
안 그러면 `thread_id` 컬럼이 없는 `chat` 에 INSERT 가 실패한다. → **DDL 적용 승인 전까지 머지 보류.**

전체 테스트 통과. 구 앱 무영향(threadId 미전송 → null 저장).

🤖 Generated with [Claude Code](https://claude.com/claude-code)