### PR TITLE
feat(v1.3.5): 스레드 통합 Phase 3a — 쓰기·읽기 라우팅

### DIFF
--- a/src/main/java/com/debateseason_backend_v1/domain/chat/application/repository/ChatRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/application/repository/ChatRepository.java
@@ -20,6 +20,15 @@ public interface ChatRepository {
 
     int countByRoomId(Long roomId);
 
+    // v1.3.5 스레드 통합: 스레드 단위 조회
+    List<ChatEntity> findByThreadIdAndCursor(Long threadId, Long cursor, Pageable pageable);
+
+    int countByThreadId(Long threadId);
+
+    List<ChatEntity> findByRoomIdAndThreadIdAndCursor(Long roomId, Long threadId, Long cursor, Pageable pageable);
+
+    int countByRoomIdAndThreadId(Long roomId, Long threadId);
+
     ChatEntity findById(Long id);
 
     // 가장 최근 대화 불러오기.

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/application/service/ChatServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/application/service/ChatServiceV1.java
@@ -14,6 +14,7 @@ import com.debateseason_backend_v1.domain.chat.presentation.dto.chat.request.Cha
 import com.debateseason_backend_v1.domain.chat.presentation.dto.chat.response.ChatMessageResponse;
 import com.debateseason_backend_v1.domain.chat.presentation.dto.chat.response.ChatMessagesResponse;
 import com.debateseason_backend_v1.domain.chat.validation.ChatValidate;
+import com.debateseason_backend_v1.domain.chatroom.domain.ChatRoomType;
 import com.debateseason_backend_v1.domain.chatroom.service.ChatRoomServiceV1;
 import com.debateseason_backend_v1.domain.notification.application.service.NotificationServiceV1;
 import com.debateseason_backend_v1.domain.repository.entity.ChatRoom;
@@ -59,8 +60,11 @@ public class ChatServiceV1 {
 		// 메시지 유효성 검사
 		chatValidate.validateMessageLength(message);
 		
-		// 채팅방 존재 여부 확인
-		ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
+		// 채팅방 존재 여부 확인 + 스레드 통합 라우팅
+		// 구 앱이 옛 방(=스레드)으로 보내면 컨테이너에 저장하고 이 방을 thread_id 로 태그한다.
+		ChatRoom target = chatRoomService.findChatRoomById(roomId);
+		RoutedTarget routed = resolveRouting(target, message.getThreadId());
+		message.setThreadId(routed.threadId());
 
 		// 인증 정보에서 사용자 ID 가져오기 (발신자를 식별할 수 없는 메시지는 저장하지 않는다)
 		Long userId = resolveUserId(headerAccessor);
@@ -70,15 +74,30 @@ public class ChatServiceV1 {
 			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_PROFILE));
 		message.setSender(profile.getNickname());
 
-		// 메시지 저장
-		ChatEntity chat = ChatEntity.from(message, chatRoom, userId);
+		// 메시지 저장 (chat_room_id = 컨테이너, thread_id = 스레드)
+		ChatEntity chat = ChatEntity.from(message, routed.container(), userId);
 		ChatEntity savedchat = chatRepository.save(chat);
 
 		// 프로필 색상 조회
 		String profileColor = profile.getProfileImage();
 
-		// 빈 반응 정보를 포함한 응답 생성
-		return ChatMessageResponse.from(savedchat, profileColor);
+		// 브로드캐스트 roomId 는 클라이언트가 구독 중인 주소(원래 roomId)로 유지 → 구 앱 실시간 호환
+		return ChatMessageResponse.from(savedchat, profileColor, roomId);
+	}
+
+	// 스레드 통합 라우팅: 발신 대상 방으로부터 (저장할 컨테이너 방, thread_id) 를 결정한다.
+	// 이관 전(레거시, room_type=NULL)에는 대상 방을 그대로 반환하므로 기존 동작과 동일하다.
+	private RoutedTarget resolveRouting(ChatRoom target, Long requestedThreadId) {
+		if (target.getRoomType() == ChatRoomType.THREAD && target.getContainerRoomId() != null) {
+			// 옛 방(스레드)로 온 발신 → 컨테이너에 저장, 이 방이 곧 스레드
+			ChatRoom container = chatRoomService.findChatRoomById(target.getContainerRoomId());
+			return new RoutedTarget(container, target.getId());
+		}
+		// CONTAINER 또는 레거시: 그대로. threadId 는 클라이언트 지정값(없으면 null = 전체)
+		return new RoutedTarget(target, requestedThreadId);
+	}
+
+	private record RoutedTarget(ChatRoom container, Long threadId) {
 	}
 
 	private Long resolveUserId(SimpMessageHeaderAccessor headerAccessor) {
@@ -97,11 +116,13 @@ public class ChatServiceV1 {
 
 	@Transactional
 	public void saveMessage(ChatMessageRequest chatMessage) {
-		ChatRoom chatRoom = chatRoomService.findChatRoomById(chatMessage.getRoomId());
-		ChatEntity chat = convertToEntity(chatMessage, chatRoom);
-		
+		ChatRoom target = chatRoomService.findChatRoomById(chatMessage.getRoomId());
+		RoutedTarget routed = resolveRouting(target, chatMessage.getThreadId());
+		chatMessage.setThreadId(routed.threadId());
+		ChatEntity chat = convertToEntity(chatMessage, routed.container());
+
 		chatRepository.save(chat);
-		log.debug("채팅 메시지 저장 완료: roomId={}, sender={}", 
+		log.debug("채팅 메시지 저장 완료: roomId={}, sender={}",
 				chatMessage.getRoomId(), chatMessage.getSender());
 	}
 
@@ -199,14 +220,27 @@ public class ChatServiceV1 {
 
 	// ---------- 채팅 메시지 조회 v2 배치쿼리 ----------
 	@Transactional(readOnly = true)
-	public ApiResult<ChatMessagesResponse> getChatMessagesV2(Long roomId, Long cursor, Long userId) {
+	public ApiResult<ChatMessagesResponse> getChatMessagesV2(Long roomId, Long threadId, Long cursor, Long userId) {
 		cursor = (cursor == null) ? Long.MAX_VALUE : cursor;
 
-		chatRoomService.findChatRoomById(roomId);
+		ChatRoom target = chatRoomService.findChatRoomById(roomId);
 
-		// 메시지 조회 (최대 20개 + 1개 더 조회하여 hasMore 확인)
-		List<ChatEntity> chats = chatRepository.findByRoomIdAndCursor(
-				roomId, cursor, PageRequest.of(0, PAGE_SIZE + 1));
+		// 조회 라우팅 (최대 20개 + 1개 더 조회하여 hasMore 확인)
+		// - THREAD(옛 방): 구 앱 히스토리 = thread_id 필터 (메시지는 컨테이너에 저장돼 있음)
+		// - CONTAINER + threadId: 웹 스레드 탭
+		// - CONTAINER/레거시: 전체 스트림 (기존 동작)
+		List<ChatEntity> chats;
+		int totalCount;
+		if (target.getRoomType() == ChatRoomType.THREAD) {
+			chats = chatRepository.findByThreadIdAndCursor(roomId, cursor, PageRequest.of(0, PAGE_SIZE + 1));
+			totalCount = chatRepository.countByThreadId(roomId);
+		} else if (threadId != null) {
+			chats = chatRepository.findByRoomIdAndThreadIdAndCursor(roomId, threadId, cursor, PageRequest.of(0, PAGE_SIZE + 1));
+			totalCount = chatRepository.countByRoomIdAndThreadId(roomId, threadId);
+		} else {
+			chats = chatRepository.findByRoomIdAndCursor(roomId, cursor, PageRequest.of(0, PAGE_SIZE + 1));
+			totalCount = chatRepository.countByRoomId(roomId);
+		}
 
 		boolean hasMore = chats.size() > PAGE_SIZE;
 
@@ -258,8 +292,6 @@ public class ChatServiceV1 {
 		if (!displayChats.isEmpty()) {
 			nextCursor = String.valueOf(displayChats.get(displayChats.size() - 1).getId());
 		}
-
-		int totalCount = chatRepository.countByRoomId(roomId);
 
 		ChatMessagesResponse response = ChatMessagesResponse.builder()
 				.items(messageResponses)

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/infrastructure/chat/ChatJpaRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/infrastructure/chat/ChatJpaRepository.java
@@ -54,6 +54,38 @@ public interface ChatJpaRepository extends JpaRepository<ChatEntity,Long> {
     int countByRoomId(Long roomId);
 
 
+    // ---- v1.3.5 스레드 통합: 스레드 단위 조회 ----
+
+    // 구 앱 히스토리 보존용: 옛 방(=스레드) id 로 조회하면 그 스레드 메시지만 돌려준다.
+    // 이관 후 메시지의 chat_room_id 는 컨테이너지만 thread_id 는 옛 방 id 로 남는다.
+    @Query("""
+           SELECT c FROM chat c
+           WHERE c.threadId = :threadId AND c.id < :cursor
+           ORDER BY c.id DESC
+           """)
+    List<ChatEntity> findByThreadIdAndCursor(Long threadId, Long cursor, Pageable pageable);
+
+    @Query("""
+           SELECT COUNT(c) FROM chat c
+           WHERE c.threadId = :threadId
+           """)
+    int countByThreadId(Long threadId);
+
+    // 웹 스레드 탭: 컨테이너 안에서 특정 스레드만 필터.
+    @Query("""
+           SELECT c FROM chat c
+           WHERE c.chatRoomId.id = :roomId AND c.threadId = :threadId AND c.id < :cursor
+           ORDER BY c.id DESC
+           """)
+    List<ChatEntity> findByRoomIdAndThreadIdAndCursor(Long roomId, Long threadId, Long cursor, Pageable pageable);
+
+    @Query("""
+           SELECT COUNT(c) FROM chat c
+           WHERE c.chatRoomId.id = :roomId AND c.threadId = :threadId
+           """)
+    int countByRoomIdAndThreadId(Long roomId, Long threadId);
+
+
     // 가장 최근대화 불러오기.
     @Query("""
             SELECT c.timeStamp FROM chat c

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/infrastructure/chat/ChatRepositoryImpl.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/infrastructure/chat/ChatRepositoryImpl.java
@@ -46,6 +46,26 @@ public class ChatRepositoryImpl implements ChatRepository {
     }
 
     @Override
+    public List<ChatEntity> findByThreadIdAndCursor(Long threadId, Long cursor, Pageable pageable) {
+        return chatJpaRepository.findByThreadIdAndCursor(threadId, cursor, pageable);
+    }
+
+    @Override
+    public int countByThreadId(Long threadId) {
+        return chatJpaRepository.countByThreadId(threadId);
+    }
+
+    @Override
+    public List<ChatEntity> findByRoomIdAndThreadIdAndCursor(Long roomId, Long threadId, Long cursor, Pageable pageable) {
+        return chatJpaRepository.findByRoomIdAndThreadIdAndCursor(roomId, threadId, cursor, pageable);
+    }
+
+    @Override
+    public int countByRoomIdAndThreadId(Long roomId, Long threadId) {
+        return chatJpaRepository.countByRoomIdAndThreadId(roomId, threadId);
+    }
+
+    @Override
     public ChatEntity findById(Long id) {
         return chatJpaRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MESSAGE));
     }

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/presentation/controller/ChatControllerV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/presentation/controller/ChatControllerV1.java
@@ -102,13 +102,21 @@ public class ChatControllerV1 {
 			example = "1234"
 		)
 		@RequestParam(required = false) Long cursor,
-		
+
+		@Parameter(
+			description = "스레드 ID (선택). 지정 시 컨테이너 채팅방 안에서 해당 스레드만 필터링(웹 탭). " +
+						"미입력 시 전체 스트림",
+			required = false,
+			example = "12"
+		)
+		@RequestParam(required = false) Long threadId,
+
 		@Parameter(hidden = true)
 		@AuthenticationPrincipal CustomUserDetails principal
 	) {
 		Long userId = requireUserId(principal);
 
-		return chatService.getChatMessagesV2(roomId, cursor, userId);
+		return chatService.getChatMessagesV2(roomId, threadId, cursor, userId);
 	}
 
 	@Operation(

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/presentation/dto/chat/response/ChatMessageResponse.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/presentation/dto/chat/response/ChatMessageResponse.java
@@ -117,6 +117,19 @@ public class ChatMessageResponse {
         return from(chat, (String) null);
     }
 
+    /**
+     * 실시간 브로드캐스트용. 저장은 컨테이너(chat_room_id)로 하되, 응답의 roomId 는 클라이언트가
+     * 실제로 구독/발신한 주소(addressedRoomId)로 맞춘다.
+     * - 구 앱: 옛 방(스레드) id 로 발신·구독 → roomId 를 그 방 id 로 유지해 호환.
+     * - 신 클라이언트: 컨테이너로 발신 → addressedRoomId == 컨테이너 == chat_room_id (동일).
+     * threadId 는 스레드 태그로 payload 에 함께 실려 웹 탭 필터에 쓰인다.
+     */
+    public static ChatMessageResponse from(ChatEntity chat, String profileColor, Long addressedRoomId) {
+        ChatMessageResponse base = from(chat, profileColor);
+        base.roomId = addressedRoomId != null ? addressedRoomId : base.roomId;
+        return base;
+    }
+
     public static ChatMessageResponse from(ChatEntity chat, String profileColor) {
         // 빈 ReactionResponse 객체 생성
         ChatReactionResponse emptyReaction = ChatReactionResponse.builder()

--- a/src/test/java/com/debateseason_backend_v1/domain/chat/ChatThreadRoutingTest.java
+++ b/src/test/java/com/debateseason_backend_v1/domain/chat/ChatThreadRoutingTest.java
@@ -1,0 +1,107 @@
+package com.debateseason_backend_v1.domain.chat;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.debateseason_backend_v1.common.enums.MessageType;
+import com.debateseason_backend_v1.domain.chat.application.repository.ChatRepository;
+import com.debateseason_backend_v1.domain.chat.application.service.ChatServiceV1;
+import com.debateseason_backend_v1.domain.chat.infrastructure.chat.ChatEntity;
+import com.debateseason_backend_v1.domain.chat.presentation.dto.chat.request.ChatMessageRequest;
+import com.debateseason_backend_v1.domain.chatroom.domain.ChatRoomType;
+import com.debateseason_backend_v1.domain.chatroom.service.ChatRoomServiceV1;
+import com.debateseason_backend_v1.domain.repository.entity.ChatRoom;
+
+/**
+ * v1.3.5 Phase 3a — 쓰기 라우팅 검증.
+ *
+ * 발신 대상 방의 종류에 따라 (chat_room_id = 컨테이너, thread_id = 스레드) 로 올바르게
+ * 저장되는지 고정한다. saveMessage 는 chatRepository / chatRoomService 만 사용하므로
+ * 나머지 협력자는 주입하지 않는다(null).
+ */
+class ChatThreadRoutingTest {
+
+	private final ChatRepository chatRepository = mock(ChatRepository.class);
+	private final ChatRoomServiceV1 chatRoomService = mock(ChatRoomServiceV1.class);
+	private final ChatServiceV1 chatService =
+		new ChatServiceV1(chatRepository, chatRoomService, null, null, null, null, null);
+
+	private ChatEntity captureSaved() {
+		ArgumentCaptor<ChatEntity> captor = ArgumentCaptor.forClass(ChatEntity.class);
+		verify(chatRepository).save(captor.capture());
+		return captor.getValue();
+	}
+
+	private ChatMessageRequest request(Long roomId, Long threadId) {
+		return ChatMessageRequest.builder()
+			.roomId(roomId)
+			.threadId(threadId)
+			.messageType(MessageType.CHAT)
+			.content("메시지")
+			.timeStamp(LocalDateTime.now())
+			.build();
+	}
+
+	@Test
+	@DisplayName("옛 방(THREAD)으로 보내면 컨테이너에 저장되고 그 방이 thread_id 가 된다 (구 앱 경로)")
+	void routesThreadToContainer() {
+		// given
+		ChatRoom thread = ChatRoom.builder()
+			.id(5L).roomType(ChatRoomType.THREAD).containerRoomId(100L).build();
+		ChatRoom container = ChatRoom.builder()
+			.id(100L).roomType(ChatRoomType.CONTAINER).build();
+		given(chatRoomService.findChatRoomById(5L)).willReturn(thread);
+		given(chatRoomService.findChatRoomById(100L)).willReturn(container);
+		given(chatRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+		// when — 구 앱은 threadId 를 안 보낸다
+		chatService.saveMessage(request(5L, null));
+
+		// then
+		ChatEntity saved = captureSaved();
+		assertThat(saved.getChatRoomId().getId()).isEqualTo(100L); // 컨테이너
+		assertThat(saved.getThreadId()).isEqualTo(5L);             // 옛 방 = 스레드
+	}
+
+	@Test
+	@DisplayName("컨테이너로 보내면 지정한 threadId 로 저장된다 (신 웹 클라이언트)")
+	void routesContainerWithThread() {
+		// given
+		ChatRoom container = ChatRoom.builder()
+			.id(100L).roomType(ChatRoomType.CONTAINER).build();
+		given(chatRoomService.findChatRoomById(100L)).willReturn(container);
+		given(chatRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+		// when — 웹이 특정 주제 탭에서 발신
+		chatService.saveMessage(request(100L, 7L));
+
+		// then
+		ChatEntity saved = captureSaved();
+		assertThat(saved.getChatRoomId().getId()).isEqualTo(100L);
+		assertThat(saved.getThreadId()).isEqualTo(7L);
+	}
+
+	@Test
+	@DisplayName("이관 전 레거시 방(room_type=NULL)은 그대로 저장된다 (기존 동작 무회귀)")
+	void legacyRoomUnchanged() {
+		// given
+		ChatRoom legacy = ChatRoom.builder().id(42L).build(); // roomType null
+		given(chatRoomService.findChatRoomById(42L)).willReturn(legacy);
+		given(chatRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+		// when
+		chatService.saveMessage(request(42L, null));
+
+		// then
+		ChatEntity saved = captureSaved();
+		assertThat(saved.getChatRoomId().getId()).isEqualTo(42L);
+		assertThat(saved.getThreadId()).isNull();
+	}
+}


### PR DESCRIPTION
PRD Phase 3a. **Phase 2 데이터 이관 전에 배포해야 하는** 라우팅 계층. 이관 전에는 `room_type` 이 전부 NULL 이라 대상 방을 그대로 반환 → **기존 동작 무회귀**.

## 쓰기 라우팅 (`ChatServiceV1`)
- 옛 방(THREAD)로 온 발신 → `chat_room_id=컨테이너`, `thread_id=그 방` (구 앱 메시지가 자동으로 컨테이너에 통합)
- 컨테이너로 온 발신 → `thread_id=클라이언트 지정값`(없으면 null=전체)
- 브로드캐스트 응답 `roomId` 는 발신 주소로 유지 → 구 앱 실시간 호환

## 읽기 라우팅 (`getChatMessagesV2`, `threadId` 파라미터 추가)
- **THREAD(옛 방) 조회 → `thread_id` 필터**: 이관돼도 구 앱 히스토리(`GET /chat/rooms/{옛방}/messages`)가 그대로 보임 ← 이관 후 파손 방지 핵심
- CONTAINER + `threadId` → 웹 스레드 탭 필터
- CONTAINER/레거시 → 전체 스트림
- 스레드 단위 쿼리 4종 신설(`idx_chat_thread_cursor` 활용)

`thread_id=NULL` = "전체/미분류"로 취급 → 별도 "전체" 스레드 행 불필요(Phase 2 단순화).

전체 테스트 통과. Expand DDL 은 이미 prod 적용 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)