### PR TITLE
feat(v1.3.5): 스레드 통합 Phase 3b — 이관 전/후 안전한 읽기 계층

### DIFF
--- a/docs/sql/v1.3.5-migrate.sql
+++ b/docs/sql/v1.3.5-migrate.sql
@@ -1,0 +1,34 @@
+-- v1.3.5 Migrate — 이슈당 채팅방 통합 (Phase 2)
+-- 선행: v1.3.5-expand.sql 적용 완료 + Phase 3a(라우팅) 코드 배포 완료.
+-- 성격: 프로덕션 데이터 쓰기. 반드시 백업 후, 트랜잭션 dry-run(ROLLBACK)으로 검증한 뒤 실행.
+--
+-- 모델: 이슈당 CONTAINER 방 1개를 새로 만들고, 기존 방을 THREAD 로 강등,
+--       메시지의 chat_room_id 를 컨테이너로 옮기고 원래 방 id 를 thread_id 에 남긴다.
+--       thread_id=NULL 은 "전체/미분류"로 취급하므로 별도 "전체" 스레드 행은 만들지 않는다.
+--       찬반·멤버십·알림(user_chat_room, chatroom_notification_setting)은 스레드(옛 방)에 그대로 둔다.
+
+-- Step 1: 이슈별 컨테이너 방 1개 생성 (기존 방이 있는 이슈만)
+INSERT INTO chat_room (issue_id, title, status, room_type, created_at, updated_at)
+SELECT d.issue_id, i.title, 'OPEN', 'CONTAINER', NOW(6), NOW(6)
+FROM (SELECT DISTINCT issue_id FROM chat_room WHERE room_type IS NULL) d
+JOIN issue i ON i.issue_id = d.issue_id;
+
+-- Step 2: 기존 방을 THREAD 로 강등하고 소속 컨테이너를 가리키게 한다
+UPDATE chat_room t
+JOIN chat_room c ON c.issue_id = t.issue_id AND c.room_type = 'CONTAINER'
+SET t.room_type = 'THREAD', t.container_room_id = c.chat_room_id
+WHERE t.room_type IS NULL;
+
+-- Step 3: 메시지를 컨테이너로 재지정, 원래 방을 thread_id 로 태그
+--   RHS 를 조인 테이블 t 로만 참조해 컬럼 대입 순서 의존성을 제거(멀티테이블 UPDATE 안전).
+UPDATE chat ch
+JOIN chat_room t ON t.chat_room_id = ch.chat_room_id
+SET ch.thread_id = t.chat_room_id, ch.chat_room_id = t.container_room_id
+WHERE t.room_type = 'THREAD' AND t.container_room_id IS NOT NULL;
+
+-- ── 롤백 (컨테이너 생성 직후 id 범위를 안다는 전제; 실제로는 백업 복원을 권장) ──
+-- UPDATE chat ch JOIN chat_room t ON t.chat_room_id = ch.thread_id
+--   SET ch.chat_room_id = ch.thread_id, ch.thread_id = NULL
+--   WHERE ch.thread_id IS NOT NULL;
+-- UPDATE chat_room SET room_type = NULL, container_room_id = NULL WHERE room_type = 'THREAD';
+-- DELETE FROM chat_room WHERE room_type = 'CONTAINER';

--- a/src/main/java/com/debateseason_backend_v1/domain/chat/infrastructure/chat/ChatJpaRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/chat/infrastructure/chat/ChatJpaRepository.java
@@ -87,9 +87,10 @@ public interface ChatJpaRepository extends JpaRepository<ChatEntity,Long> {
 
 
     // 가장 최근대화 불러오기.
+    // v1.3.5: 호출부는 주제(스레드) id 를 넘긴다. 이관 전/후 모두 주제 메시지의 최신 시각을 반환.
     @Query("""
             SELECT c.timeStamp FROM chat c
-            WHERE c.chatRoomId.id = :chatRoomId
+            WHERE (c.threadId = :chatRoomId OR (c.threadId IS NULL AND c.chatRoomId.id = :chatRoomId))
             ORDER BY c.timeStamp
             DESC
             LIMIT 1

--- a/src/main/java/com/debateseason_backend_v1/domain/notification/application/service/NotificationServiceV1.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/notification/application/service/NotificationServiceV1.java
@@ -40,10 +40,12 @@ public class NotificationServiceV1 {
             return;
         }
 
-        Long roomId = chat.getChatRoomId().getId();
+        // v1.3.5: 알림 대상은 주제(스레드) 단위. 이관 후 chat_room_id 는 컨테이너이므로
+        // thread_id 가 있으면 그 방(옛 주제)을, 없으면 chat_room_id 를 대상 방으로 쓴다.
+        Long roomId = chat.getThreadId() != null ? chat.getThreadId() : chat.getChatRoomId().getId();
         Long senderUserId = chat.getUserId();
 
-        List<UserChatRoom> participants = userChatRoomRepository.findByChatRoom(chat.getChatRoomId());
+        List<UserChatRoom> participants = userChatRoomRepository.findByChatRoom_Id(roomId);
 
         List<Long> recipientUserIds = participants.stream()
                 .map(ucr -> ucr.getUser().getId())

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/ChatRoomRepository.java
@@ -20,10 +20,11 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
 
 	// 2-1 이슈방 issue-id와 관련된 채팅방ID 가져오기
-	@Query(value = "SELECT chat_room_id FROM chat_room WHERE issue_id = :issueId ORDER BY chat_room_id DESC LIMIT 3", nativeQuery = true)
+	// v1.3.5: 컨테이너는 목록에서 제외(스레드=옛 방만 노출). 레거시(NULL)도 스레드로 취급.
+	@Query(value = "SELECT chat_room_id FROM chat_room WHERE issue_id = :issueId AND (room_type IS NULL OR room_type <> 'CONTAINER') ORDER BY chat_room_id DESC LIMIT 3", nativeQuery = true)
 	List<Long> findTop3ChatRoomIdsByIssueId(@Param("issueId") Long issueId);
 	// 2-2 이슈방 issue-id와 관련된 채팅방ID + 커서기반
-	@Query(value = "SELECT chat_room_id FROM chat_room WHERE issue_id = :issueId AND chat_room_id < :ChatRoomId ORDER BY chat_room_id DESC LIMIT 3", nativeQuery = true)
+	@Query(value = "SELECT chat_room_id FROM chat_room WHERE issue_id = :issueId AND chat_room_id < :ChatRoomId AND (room_type IS NULL OR room_type <> 'CONTAINER') ORDER BY chat_room_id DESC LIMIT 3", nativeQuery = true)
 	List<Long> findTop3ChatRoomIdsByIssueIdAndChatRoomId(
 		@Param("issueId") Long issueId,
 		@Param("ChatRoomId") Long ChatRoomId
@@ -55,14 +56,16 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
         INNER JOIN (
             SELECT chat_room_id
             FROM (
-                SELECT chat_room_id, COUNT(chat_room_id) AS chats 
+                -- v1.3.5: 이관 전/후 모두 주제 단위 랭킹 (post: thread_id / pre: chat_room_id)
+                SELECT COALESCE(thread_id, chat_room_id) AS chat_room_id, COUNT(*) AS chats
                 FROM chat
                 WHERE time_stamp <= NOW()
-                GROUP BY chat_room_id
+                GROUP BY COALESCE(thread_id, chat_room_id)
             ) tmp
             ORDER BY tmp.chats DESC
             LIMIT 5
         ) tmp2 ON cr.chat_room_id = tmp2.chat_room_id
+        WHERE cr.room_type IS NULL OR cr.room_type <> 'CONTAINER'
     ) chatroom ON iss.issue_id = chatroom.issue_id
 """, nativeQuery = true)
 	List<Object[]> findTop5ActiveChatRooms();
@@ -86,15 +89,17 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             cr.created_at
         FROM chat_room cr
         INNER JOIN (
-            SELECT 
-                chat_room_id, 
-                COUNT(chat_room_id) AS chats 
+            -- v1.3.5: 이관 전/후 모두 주제 단위 랭킹 (post: thread_id / pre: chat_room_id).
+            -- 컨테이너는 votes(user_chat_room)가 없어 아래 INNER JOIN 에서 자연 제외된다.
+            SELECT
+                COALESCE(thread_id, chat_room_id) AS chat_room_id,
+                COUNT(*) AS chats
             FROM chat
             WHERE time_stamp <= NOW()
-            GROUP BY chat_room_id
+            GROUP BY COALESCE(thread_id, chat_room_id)
             ORDER BY chats DESC
-            LIMIT 5       
-        ) tmp2 
+            LIMIT 5
+        ) tmp2
         ON cr.chat_room_id = tmp2.chat_room_id
     ) tmp3
     ON ucr.chat_room_id = tmp3.chat_room_id
@@ -134,7 +139,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
         SELECT COUNT(CASE WHEN reaction_type = 'LOGIC' THEN 1 END) AS LOGIC,
                COUNT(CASE WHEN reaction_type = 'ATTITUDE' THEN 1 END) AS ATTITUDE
         FROM (
-            SELECT chat_id FROM chat WHERE chat_room_id = :chatRoomId AND opinion_type = :opinion
+            SELECT chat_id FROM chat WHERE (thread_id = :chatRoomId OR (thread_id IS NULL AND chat_room_id = :chatRoomId)) AND opinion_type = :opinion
         ) ch
         JOIN chat_reaction ch_r ON ch.chat_id = ch_r.chat_id
         GROUP BY ch.chat_id
@@ -156,7 +161,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
                     COUNT(CASE WHEN ch_r.reaction_type = 'ATTITUDE' THEN 1 END) AS score
                 FROM chat ch
                 JOIN chat_reaction ch_r ON ch.chat_id = ch_r.chat_id
-                WHERE ch.chat_room_id = :chatRoomId AND ch.opinion_type = :opinion
+                WHERE (ch.thread_id = :chatRoomId OR (ch.thread_id IS NULL AND ch.chat_room_id = :chatRoomId)) AND ch.opinion_type = :opinion
                 GROUP BY ch.chat_id
             ) s
             ORDER BY s.score DESC
@@ -174,8 +179,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
         COUNT(CASE WHEN ch_r.reaction_type = 'LOGIC' THEN 1 END) AS logic,
         COUNT(CASE WHEN ch_r.reaction_type = 'ATTITUDE' THEN 1 END) AS attitude
     FROM (
-        SELECT * FROM chat 
-        WHERE user_id = :userId AND chat_room_id = :chatRoomId
+        SELECT * FROM chat
+        WHERE user_id = :userId AND (thread_id = :chatRoomId OR (thread_id IS NULL AND chat_room_id = :chatRoomId))
     ) ch
     JOIN chat_reaction ch_r ON ch.chat_id = ch_r.chat_id
     GROUP BY ch.chat_id, ch.content

--- a/src/main/java/com/debateseason_backend_v1/domain/repository/UserChatRoomRepository.java
+++ b/src/main/java/com/debateseason_backend_v1/domain/repository/UserChatRoomRepository.java
@@ -14,6 +14,9 @@ import com.debateseason_backend_v1.domain.repository.entity.UserChatRoom;
 @Repository
 public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long> {
 	List<UserChatRoom> findByChatRoom(ChatRoom chatRoom);
+
+	// v1.3.5: 방 id 로 멤버십 조회 (알림 수신자 해석 — 스레드=옛 방 단위)
+	List<UserChatRoom> findByChatRoom_Id(Long chatRoomId);
 	UserChatRoom findByUserAndChatRoom(UserEntity user, ChatRoom chatRoom);
 	UserChatRoom findByUserIdAndChatRoomId(Long userId,Long chatroomId);
 


### PR DESCRIPTION
이관으로 `chat.chat_room_id` 가 주제→컨테이너로 바뀌면 `chat_room_id=주제`를 가정하던 집계 read 들이 깨진다(팀점수·MVP·홈 Top5·최근시각·알림). **이관 전 데이터에서도 동작해야 무중단 배포**가 되므로, 주제를 이관 전/후 모두 가리키는 조건으로 통일:

```sql
(thread_id = :id OR (thread_id IS NULL AND chat_room_id = :id))   -- 필터
COALESCE(thread_id, chat_room_id)                                  -- 그룹핑
```

## 변경
- **ChatRoomRepository**: `getReactionSummaryByOpinion`/`findTopChatRoomUserNickname`/`findChatHighlight` → 주제 조건 통일. `findTop5Active`/`OrderedByChatCounts` → COALESCE 그룹핑(+컨테이너 제외). `findTop3ChatRoomIdsByIssueId`(+커서) → 컨테이너 제외
- **ChatJpaRepository**: 최근시각 쿼리 → 주제 조건
- **UserChatRoomRepository**: `findByChatRoom_Id` 추가
- **NotificationServiceV1**: 수신자·딥링크를 주제(스레드) 단위로 (현재 미호출 dead code지만 landmine 방지)
- `docs/sql/v1.3.5-migrate.sql`: 이관 스크립트(+롤백)

## 배경 — 이관 리허설/롤백 완료
Expand DDL + Phase 3a 배포 후 실제 이관을 트랜잭션 dry-run→커밋→검증까지 진행했고, **읽기 계층 회귀(이 PR이 해결)를 확인해 이관을 롤백**했다. prod 는 현재 baseline. 이 PR 배포 후 재이관 예정.

**검증**: pre-migration prod 데이터에서 새 쿼리 = 기존 결과(방57 113=113, Top5 동일). thread_id 미도입 상태라 **무회귀**. 전체 테스트 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)